### PR TITLE
install fonts and font config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM python:3.5.7-stretch
+FROM python:3.5.7-buster
 
-RUN apt-get update
-RUN apt-get install -y libreoffice-writer
+# install LibreOffice Write to convert Word to PDF
+# also install fonts and fontconfig to provide common fonts or configuration to their alternatives
+RUN apt-get update \
+  && apt-get install -y \
+    libreoffice-writer \
+    fonts-liberation fonts-liberation2 \
+    fonts-crosextra-carlito fonts-crosextra-caladea \
+    fontconfig \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV PROJECT_HOME=/srv/sciencebeam
 


### PR DESCRIPTION
We can't re-distribute MS fonts due to the license.

Instead this will install some common free fonts.
We are also installing fontconfig which will provide us with some mapping from non-free fonts to free fonts.

The [fontconfig version provided by `stretch`](https://gitlab.freedesktop.org/fontconfig/fontconfig/tree/2.11.0) doesn't include the mapping for fonts like `Cambria Math`, which is provide by the [fontconfig version in `buster`](https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/2.13.1/conf.d/45-generic.conf#L90-93).

```xml
	<alias binding="same">
		<family>Cambria Math</family> <!-- Microsoft -->
		<default><family>math</family></default>
	</alias>
```

/cc @diversemix 