### PR TITLE
fix multiple affiliation markers

### DIFF
--- a/sciencebeam_parser/models/name/extract.py
+++ b/sciencebeam_parser/models/name/extract.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Iterable, List, Mapping, Optional, Tuple, Type, cast
+from typing import Iterable, List, Mapping, Optional, Tuple, Type, Union, cast
 
 from sciencebeam_parser.document.semantic_document import (
     SemanticAuthor,
     SemanticContentFactoryProtocol,
+    SemanticContentWrapper,
     SemanticMarker,
     SemanticMiddleName,
     SemanticNamePart,
@@ -93,6 +94,12 @@ def normalize_name_parts(name: T_SemanticName):
     return name
 
 
+def iter_semantic_markers_for_layout_block(
+    layout_block: LayoutBlock
+) -> Iterable[Union[SemanticMarker, SemanticContentWrapper]]:
+    return [SemanticMarker(layout_block=layout_block)]
+
+
 class NameSemanticExtractor(SimpleModelSemanticExtractor):
     def __init__(self):
         super().__init__(semantic_content_class_by_tag=SIMPLE_SEMANTIC_CONTENT_CLASS_BY_TAG)
@@ -119,7 +126,8 @@ class NameSemanticExtractor(SimpleModelSemanticExtractor):
                 if not semantic_name:
                     LOGGER.debug('new semantic_name with marker in the beginning')
                     semantic_name = _name_type()
-                    semantic_name.add_content(SemanticMarker(layout_block=layout_block))
+                    for semantic_marker in iter_semantic_markers_for_layout_block(layout_block):
+                        semantic_name.add_content(semantic_marker)
                     continue
                 if len(seen_entity_tokens) >= 2 and seen_name_labels and not has_tail_marker:
                     previous_layout_block = seen_entity_tokens[-2][1]

--- a/tests/document/tei/author_test.py
+++ b/tests/document/tei/author_test.py
@@ -8,8 +8,10 @@ from sciencebeam_parser.document.layout_document import (
 from sciencebeam_parser.document.semantic_document import (
     SemanticAddressLine,
     SemanticAffiliationAddress,
+    SemanticAuthor,
     SemanticCountry,
     SemanticDepartment,
+    SemanticGivenName,
     SemanticInstitution,
     SemanticLaboratory,
     SemanticMarker,
@@ -17,13 +19,15 @@ from sciencebeam_parser.document.semantic_document import (
     SemanticPostCode,
     SemanticRegion,
     SemanticSettlement,
+    SemanticSurname,
 )
 from sciencebeam_parser.document.tei.common import TeiElementWrapper
 from sciencebeam_parser.document.tei.factories import (
     DEFAULT_TEI_ELEMENT_FACTORY_CONTEXT
 )
 from sciencebeam_parser.document.tei.author import (
-    get_tei_affiliation_for_semantic_affiliation_address_element
+    get_tei_affiliation_for_semantic_affiliation_address_element,
+    get_tei_author_for_semantic_author_element
 )
 from tests.document.tei.common_test import (
     ITALICS_FONT_1,
@@ -128,3 +132,44 @@ class TestGetTeiAffiliationForSemanticAffiliationAddress:
         assert tei_aff.get_xpath_text_content_list(
             'tei:note[@type="raw_affiliation"]/tei:label'
         ) == ['1']
+
+
+class TestGetTeiAuthorForSemanticAffiliationAddress:
+    def test_should_add_all_fields(self):
+        affiliations_by_marker = {
+            '1': [SemanticAffiliationAddress([
+                SemanticInstitution(layout_block=LayoutBlock.for_text('Institution1'))
+            ])],
+            '2': [SemanticAffiliationAddress([
+                SemanticInstitution(layout_block=LayoutBlock.for_text('Institution2'))
+            ])],
+            '3': [SemanticAffiliationAddress([
+                SemanticInstitution(layout_block=LayoutBlock.for_text('Other'))
+            ])]
+        }
+        semantic_author = SemanticAuthor([
+            SemanticMarker(layout_block=LayoutBlock.for_text('1')),
+            SemanticMarker(layout_block=LayoutBlock.for_text('2')),
+            SemanticGivenName(layout_block=LayoutBlock.for_text('GivenName1')),
+            SemanticSurname(layout_block=LayoutBlock.for_text('Surname1'))
+        ])
+        tei_author = TeiElementWrapper(
+            get_tei_author_for_semantic_author_element(
+                semantic_author,
+                context=DEFAULT_TEI_ELEMENT_FACTORY_CONTEXT,
+                affiliations_by_marker=affiliations_by_marker
+            )
+        )
+        LOGGER.debug('tei_author: %r', etree.tostring(tei_author.element))
+        assert tei_author.get_xpath_text_content_list(
+            '//tei:note[@type="marker"]'
+        ) == ['1', '2']
+        assert tei_author.get_xpath_text_content_list(
+            'tei:persName/tei:forename'
+        ) == ['GivenName1']
+        assert tei_author.get_xpath_text_content_list(
+            'tei:persName/tei:surname'
+        ) == ['Surname1']
+        assert tei_author.get_xpath_text_content_list(
+            'tei:affiliation/tei:orgName[@type="institution"]'
+        ) == ['Institution1', 'Institution2']


### PR DESCRIPTION
When multiple affiliation markers are used, these were previously not split as the machine learning model doesn't tag them as separate entities.
e.g. `1,2,3`.

This marker is now split on any character that isn't a digit.

A current downside is that the original block formatting isn't preserved.