### PR TITLE
optionally replace text by cv graphic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,6 +66,7 @@ processors:
     use_cv_model: false
     cv_render_dpi: 100
     use_ocr_model: false
+    replace_text_by_cv_graphic: false
 models:
   segmentation:
     path: 'https://github.com/elifesciences/sciencebeam-models/releases/download/biorxiv-grobid/2021-05-11-delft-grobid-segmentation-biorxiv-10k-auto-v0.0.23-train-1966-e133.tar.gz'

--- a/sciencebeam_parser/processors/fulltext/config.py
+++ b/sciencebeam_parser/processors/fulltext/config.py
@@ -45,6 +45,7 @@ class FullTextProcessorConfig(NamedTuple):
     use_cv_model: bool = False
     cv_render_dpi: float = DEFAULT_PDF_RENDER_DPI
     use_ocr_model: bool = False
+    replace_text_by_cv_graphic: bool = False
 
     @staticmethod
     def from_app_config(app_config: AppConfig) -> 'FullTextProcessorConfig':

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -82,7 +82,7 @@ from sciencebeam_parser.processors.graphic_provider import (
     DocumentGraphicProvider,
     SimpleDocumentGraphicProvider,
     get_layout_document_with_graphics_replaced_by_graphics,
-    get_layout_document_with_text_replaced_by_graphics,
+    get_layout_document_with_text_and_graphics_replaced_by_graphics,
     get_page_numbers_for_semantic_content_list,
     get_page_numbers_with_mostly_bitmap_graphics,
     get_page_numbers_with_uncommon_page_dimension
@@ -329,7 +329,7 @@ class FullTextProcessor:
                 layout_document,
                 semantic_graphics
             )
-        return get_layout_document_with_text_replaced_by_graphics(
+        return get_layout_document_with_text_and_graphics_replaced_by_graphics(
             layout_document,
             semantic_graphics
         )

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -81,6 +81,7 @@ from sciencebeam_parser.processors.graphic_matching import (
 from sciencebeam_parser.processors.graphic_provider import (
     DocumentGraphicProvider,
     SimpleDocumentGraphicProvider,
+    get_layout_document_with_graphics_replaced_by_graphics,
     get_layout_document_with_text_replaced_by_graphics,
     get_page_numbers_for_semantic_content_list,
     get_page_numbers_with_mostly_bitmap_graphics,
@@ -323,6 +324,11 @@ class FullTextProcessor:
         if not semantic_graphics:
             LOGGER.info('no semantic graphics found on pages %r', candidate_page_numbers)
             return layout_document
+        if not self.config.replace_text_by_cv_graphic:
+            return get_layout_document_with_graphics_replaced_by_graphics(
+                layout_document,
+                semantic_graphics
+            )
         return get_layout_document_with_text_replaced_by_graphics(
             layout_document,
             semantic_graphics

--- a/sciencebeam_parser/processors/graphic_provider.py
+++ b/sciencebeam_parser/processors/graphic_provider.py
@@ -260,7 +260,7 @@ def get_layout_document_with_text_or_graphic_replaced_by_graphics(
     return layout_document.replace(pages=pages)
 
 
-def get_layout_document_with_text_replaced_by_graphics(
+def get_layout_document_with_text_and_graphics_replaced_by_graphics(
     layout_document: LayoutDocument,
     semantic_graphics: Iterable[SemanticGraphic]
 ) -> LayoutDocument:

--- a/tests/processors/graphic_provider_test.py
+++ b/tests/processors/graphic_provider_test.py
@@ -15,7 +15,7 @@ from sciencebeam_parser.document.layout_document import (
 from sciencebeam_parser.processors.graphic_provider import (
     SimpleDocumentGraphicProvider,
     get_layout_document_with_graphics_replaced_by_graphics,
-    get_layout_document_with_text_replaced_by_graphics,
+    get_layout_document_with_text_and_graphics_replaced_by_graphics,
     get_page_numbers_with_mostly_bitmap_graphics,
     get_page_numbers_with_uncommon_page_dimension
 )
@@ -165,10 +165,10 @@ class TestGetPageNumbersWithMostlyBitmapGraphics:
         assert result == []
 
 
-class TestGetLayoutDocumentWithTextReplacedByGraphics:
+class TestGetLayoutDocumentWithTextAndGraphicsReplacedByGraphics:
     def test_should_not_change_layout_document_if_semantic_graphics_is_empty(self):
         layout_document = LayoutDocument(pages=[])
-        result = get_layout_document_with_text_replaced_by_graphics(
+        result = get_layout_document_with_text_and_graphics_replaced_by_graphics(
             layout_document,
             semantic_graphics=[]
         )
@@ -227,7 +227,7 @@ class TestGetLayoutDocumentWithTextReplacedByGraphics:
             coordinates=empty_coordinates,
             graphic_type='empty-coords-graphic'
         )
-        result = get_layout_document_with_text_replaced_by_graphics(
+        result = get_layout_document_with_text_and_graphics_replaced_by_graphics(
             layout_document,
             semantic_graphics=[
                 SemanticGraphic(layout_graphic=layout_graphic),

--- a/tests/processors/graphic_provider_test.py
+++ b/tests/processors/graphic_provider_test.py
@@ -174,7 +174,7 @@ class TestGetLayoutDocumentWithTextAndGraphicsReplacedByGraphics:
         )
         assert result == layout_document
 
-    def test_should_replacing_text_and_graphics_within_bounding_box_of_semantic_graphics(
+    def test_should_replace_text_and_graphics_within_bounding_box_of_semantic_graphics(
         self
     ):
         page_coordinates = LayoutPageCoordinates.from_bounding_box(

--- a/tests/processors/graphic_provider_test.py
+++ b/tests/processors/graphic_provider_test.py
@@ -14,6 +14,7 @@ from sciencebeam_parser.document.layout_document import (
 )
 from sciencebeam_parser.processors.graphic_provider import (
     SimpleDocumentGraphicProvider,
+    get_layout_document_with_graphics_replaced_by_graphics,
     get_layout_document_with_text_replaced_by_graphics,
     get_page_numbers_with_mostly_bitmap_graphics,
     get_page_numbers_with_uncommon_page_dimension
@@ -242,6 +243,81 @@ class TestGetLayoutDocumentWithTextReplacedByGraphics:
         assert list(result.pages[0].graphics[-1].related_block.iter_all_tokens()) == [
             keep_token, remove_token
         ]
+
+
+class TestGetLayoutDocumentWithGraphicsReplacedByGraphics:
+    def test_should_not_change_layout_document_if_semantic_graphics_is_empty(self):
+        layout_document = LayoutDocument(pages=[])
+        result = get_layout_document_with_graphics_replaced_by_graphics(
+            layout_document,
+            semantic_graphics=[]
+        )
+        assert result == layout_document
+
+    def test_should_replace_graphics_but_not_text_within_bounding_box_of_semantic_graphics(
+        self
+    ):
+        page_coordinates = LayoutPageCoordinates.from_bounding_box(
+            BoundingBox(0, 0, 200, 200),
+            page_number=1
+        )
+        semantic_graphic_coordinates = LayoutPageCoordinates.from_bounding_box(
+            BoundingBox(10, 90, 100, 50),
+            page_number=1
+        )
+        keep_coordinates = LayoutPageCoordinates.from_bounding_box(
+            BoundingBox(10, 10, 100, 20),
+            page_number=1
+        )
+        remove_coordinates = LayoutPageCoordinates.from_bounding_box(
+            BoundingBox(10, 100, 100, 20),
+            page_number=1
+        )
+        empty_coordinates = LayoutPageCoordinates.from_bounding_box(
+            BoundingBox(10, 100, 0, 0),
+            page_number=1
+        )
+        non_overlapping_token = LayoutToken('keep', coordinates=keep_coordinates)
+        overlapping_token = LayoutToken('remove', coordinates=remove_coordinates)
+        all_tokens = [non_overlapping_token, overlapping_token]
+        keep_graphic = LayoutGraphic(coordinates=keep_coordinates, graphic_type='keep-graphic')
+        remove_graphic = LayoutGraphic(
+            coordinates=remove_coordinates, graphic_type='remove-graphic'
+        )
+        layout_document = LayoutDocument(pages=[
+            LayoutPage(
+                blocks=[LayoutBlock(lines=[LayoutLine(tokens=all_tokens)])],
+                graphics=[
+                    keep_graphic,
+                    remove_graphic
+                ],
+                meta=LayoutPageMeta(
+                    page_number=page_coordinates.page_number,
+                    coordinates=page_coordinates
+                )
+            )
+        ])
+        layout_graphic = LayoutGraphic(
+            coordinates=semantic_graphic_coordinates,
+            graphic_type='new-graphic'
+        )
+        no_coords_layout_graphic = LayoutGraphic(
+            coordinates=empty_coordinates,
+            graphic_type='empty-coords-graphic'
+        )
+        result = get_layout_document_with_graphics_replaced_by_graphics(
+            layout_document,
+            semantic_graphics=[
+                SemanticGraphic(layout_graphic=layout_graphic),
+                SemanticGraphic(layout_graphic=no_coords_layout_graphic)
+            ]
+        )
+        LOGGER.debug('result.pages[0].graphics: %r', result.pages[0].graphics)
+        assert result.pages[0].graphics[:-1] == [keep_graphic]
+        LOGGER.debug('result.pages[0].graphics[-1]: %r', result.pages[0].graphics[-1])
+        assert result.pages[0].graphics[-1].graphic_type == layout_graphic.graphic_type
+        assert result.pages[0].graphics[-1].coordinates == layout_graphic.coordinates
+        assert list(result.pages[0].blocks[0].iter_all_tokens()) == all_tokens
 
 
 class TestSimpleDocumentGraphicProvider:


### PR DESCRIPTION
When the Computer Vision model is enabled, it was used to find figure images on pages with "unusually" page dimension.
Text that overlapped with those graphics was removed.
This makes the replacement of the text optional and disables it by default.
(configuration option `replace_text_by_cv_graphic`)