### PR TITLE
fixed missing setup resources in python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ COPY tests ./tests
 COPY test-data ./test-data
 COPY scripts/dev ./scripts/dev
 COPY doc ./doc
-COPY .flake8 .pylintrc setup.py README.md ./
+COPY .flake8 .pylintrc setup.py MANIFEST.in README.md ./
 
 # temporary workaround for tesserocr https://github.com/sirfz/tesserocr/issues/165
 ENV LC_ALL=C

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include doc
-include sciencebeam_parser
+graft doc
+graft sciencebeam_parser
 include requirements.txt
 include requirements.*.txt
 prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 graft doc
-graft sciencebeam_parser
 include requirements.txt
 include requirements.*.txt
 prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include doc
+include sciencebeam_parser
+include requirements.txt
+include requirements.*.txt
+prune tests
+prune .*

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ dev-end-to-end:
 		> /dev/null
 
 
+dev-build-dist:
+	$(PYTHON) setup.py sdist
+
+
 run:
 	$(PYTHON) -m sciencebeam_parser $(ARGS)
 

--- a/requirements.cv.txt
+++ b/requirements.cv.txt
@@ -1,4 +1,5 @@
 layoutparser[effdet]==0.3.2
+matplotlib<3.5.0
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.1+cpu
 torchvision==0.10.1+cpu


### PR DESCRIPTION
The installation of the python package from pypi failed due to missing resources, such as `requirements.txt`.
When using tools like `setuptools_scm` these seem to be included automatically.
In the absence of that, we can specify them using the [MANIFEST.in](https://packaging.python.org/guides/using-manifest-in/) file.