### PR TITLE
added Jupyter notebook support

### DIFF
--- a/sciencebeam_parser/external/pdfalto/wrapper.py
+++ b/sciencebeam_parser/external/pdfalto/wrapper.py
@@ -1,10 +1,9 @@
 import logging
 import os
 import stat
-import sys
 from typing import Optional
 
-from subprocess import Popen, STDOUT
+from sciencebeam_parser.utils.background_process import exec_with_logging
 
 
 LOGGER = logging.getLogger(__name__)
@@ -45,5 +44,5 @@ class PdfAltoWrapper:
         command = self.get_command(*args, **kwargs)
         LOGGER.info('command: %s', command)
         LOGGER.info('command str: %s', ' '.join(command))
-        with Popen(command, stdout=sys.stderr, stderr=STDOUT) as _:
+        with exec_with_logging(command, logging_prefix='pdfalto') as _:
             pass

--- a/sciencebeam_parser/utils/background_process.py
+++ b/sciencebeam_parser/utils/background_process.py
@@ -40,6 +40,12 @@ class BackgroundProcess:
             self=self
         )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, value, traceback):
+        self.process.__exit__(exc_type, value, traceback)
+
     def is_running(self) -> bool:
         self.process.poll()
         return self.returncode is None


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/231

Currently attempting to run ScienceBeam Parser within a Jupyter notebook fails due to passing `sys.stderr` to `Popen` when calling `pdfalto`. Within a Jupyter notebook `sys.stderr` doesn't have a `fileno` which trips over `Popen`.
This pipes the output to logging, which is preferable anyway (as we can see where it is coming from).