### PR TITLE
fixed asset zip failing with assert on relative path

### DIFF
--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -57,6 +57,10 @@ DOC_TO_PDF_SUPPORTED_MEDIA_TYPES = {
 }
 
 
+JATS_MEDIA_TYPES = {MediaTypes.JATS_XML, MediaTypes.JATS_ZIP}
+ASSET_ZIP_MEDIA_TYPES = {MediaTypes.TEI_ZIP, MediaTypes.JATS_ZIP}
+
+
 def normalize_and_tokenize_text(text: str) -> List[str]:
     return get_tokenized_tokens(
         normalize_text(text),
@@ -317,13 +321,13 @@ class ScienceBeamParserSessionParsedSemanticDocument(_ScienceBeamParserSessionDe
         )
         xml_root = tei_document.root
         relative_xml_filename = 'tei.xml'
-        if response_media_type in {MediaTypes.JATS_XML, MediaTypes.JATS_ZIP}:
+        if response_media_type in JATS_MEDIA_TYPES:
             xml_root = self._get_tei_to_jats_xml_root(xml_root)
             relative_xml_filename = 'jats.xml'
         local_xml_filename = os.path.join(self.temp_dir, relative_xml_filename)
         self._serialize_xml_to_file(xml_root, local_xml_filename)
         LOGGER.debug('local_xml_filename: %r', local_xml_filename)
-        if response_media_type in {MediaTypes.TEI_ZIP, MediaTypes.JATS_ZIP}:
+        if response_media_type in ASSET_ZIP_MEDIA_TYPES:
             zip_filename = os.path.join(self.temp_dir, 'results.zip')
             create_asset_zip_for_semantic_document(
                 zip_filename,
@@ -390,6 +394,9 @@ class ScienceBeamParserSessionParsedLayoutDocument(_ScienceBeamParserSessionDeri
     ) -> str:
         if response_media_type == MediaTypes.PDF:
             return self.pdf_path
+        if response_media_type in ASSET_ZIP_MEDIA_TYPES:
+            assert self.session.fulltext_processor_config.extract_graphic_assets, \
+                "extract_graphic_assets required for asset zip"
         return self.get_parsed_semantic_document().get_local_file_for_response_media_type(
             response_media_type
         )

--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -111,7 +111,8 @@ def create_asset_zip_for_semantic_document(
             relative_xml_filename
         )
         for semantic_graphic in semantic_graphic_list:
-            assert semantic_graphic.relative_path
+            assert semantic_graphic.relative_path, \
+                "graphic relative_path missing, ensure extract_graphic_assets was enabled"
             layout_graphic = semantic_graphic.layout_graphic
             assert layout_graphic
             assert layout_graphic.local_file_path

--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -377,11 +377,14 @@ class ScienceBeamParserSessionParsedLayoutDocument(_ScienceBeamParserSessionDeri
 
     def get_parsed_semantic_document(
         self,
+        fulltext_processor_config: Optional[FullTextProcessorConfig] = None
     ) -> ScienceBeamParserSessionParsedSemanticDocument:
+        if fulltext_processor_config is None:
+            fulltext_processor_config = self.session.fulltext_processor_config
         fulltext_processor = FullTextProcessor(
             self.fulltext_models,
             app_features_context=self.app_features_context,
-            config=self.session.fulltext_processor_config
+            config=fulltext_processor_config
         )
         return ScienceBeamParserSessionParsedSemanticDocument(
             self.session,
@@ -394,11 +397,20 @@ class ScienceBeamParserSessionParsedLayoutDocument(_ScienceBeamParserSessionDeri
     ) -> str:
         if response_media_type == MediaTypes.PDF:
             return self.pdf_path
+        fulltext_processor_config = self.session.fulltext_processor_config
         if response_media_type in ASSET_ZIP_MEDIA_TYPES:
-            assert self.session.fulltext_processor_config.extract_graphic_assets, \
+            fulltext_processor_config = (
+                fulltext_processor_config
+                ._replace(extract_graphic_assets=True)
+            )
+            assert fulltext_processor_config.extract_graphic_assets, \
                 "extract_graphic_assets required for asset zip"
-        return self.get_parsed_semantic_document().get_local_file_for_response_media_type(
-            response_media_type
+        return (
+            self.get_parsed_semantic_document(
+                fulltext_processor_config
+            ).get_local_file_for_response_media_type(
+                response_media_type
+            )
         )
 
 

--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -401,7 +401,10 @@ class ScienceBeamParserSessionParsedLayoutDocument(_ScienceBeamParserSessionDeri
         if response_media_type in ASSET_ZIP_MEDIA_TYPES:
             fulltext_processor_config = (
                 fulltext_processor_config
-                ._replace(extract_graphic_assets=True)
+                ._replace(
+                    extract_graphic_assets=True,
+                    extract_graphic_bounding_boxes=True
+                )
             )
             assert fulltext_processor_config.extract_graphic_assets, \
                 "extract_graphic_assets required for asset zip"

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -307,6 +307,7 @@ class TestScienceBeamParser:
             self,
             sciencebeam_parser_session: ScienceBeamParserSession,
             get_tei_for_semantic_document_mock: MagicMock,
+            full_text_processor_class_mock: MagicMock,
             full_text_processor_mock: MagicMock,
             request_temp_path: Path
         ):
@@ -344,11 +345,15 @@ class TestScienceBeamParser:
                 assert tei_xml_data == TEI_XML_CONTENT_1
                 image_data = zip_file.read(graphic_relative_path)
                 assert image_data == IMAGE_DATA_1
+            full_text_processor_kwargs = full_text_processor_class_mock.call_args[1]
+            full_text_processor_config = full_text_processor_kwargs['config']
+            assert full_text_processor_config.extract_graphic_assets is True
 
         def test_should_not_convert_pdf_to_jats_zip(
             self,
             sciencebeam_parser_session: ScienceBeamParserSession,
             get_tei_for_semantic_document_mock: MagicMock,
+            full_text_processor_class_mock: MagicMock,
             full_text_processor_mock: MagicMock,
             xslt_transformer_wrapper_mock: MagicMock,
             request_temp_path: Path
@@ -390,3 +395,6 @@ class TestScienceBeamParser:
                 assert jats_xml_data == JATS_XML_CONTENT_1
                 image_data = zip_file.read(graphic_relative_path)
                 assert image_data == IMAGE_DATA_1
+            full_text_processor_kwargs = full_text_processor_class_mock.call_args[1]
+            full_text_processor_config = full_text_processor_kwargs['config']
+            assert full_text_processor_config.extract_graphic_assets is True

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -303,7 +303,7 @@ class TestScienceBeamParser:
             )
             assert Path(result_file).read_bytes() == JATS_XML_CONTENT_1
 
-        def test_should_not_convert_pdf_to_tei_zip(
+        def test_should_not_convert_pdf_to_tei_zip(  # pylint: disable=too-many-locals
             self,
             sciencebeam_parser_session: ScienceBeamParserSession,
             get_tei_for_semantic_document_mock: MagicMock,
@@ -349,7 +349,7 @@ class TestScienceBeamParser:
             full_text_processor_config = full_text_processor_kwargs['config']
             assert full_text_processor_config.extract_graphic_assets is True
 
-        def test_should_not_convert_pdf_to_jats_zip(
+        def test_should_not_convert_pdf_to_jats_zip(  # pylint: disable=too-many-locals
             self,
             sciencebeam_parser_session: ScienceBeamParserSession,
             get_tei_for_semantic_document_mock: MagicMock,


### PR DESCRIPTION
part of #468

Previous refactoring seem to have caused a bug where `extract_graphic_assets` was no longer set when an asset zip was requested.
As a result, when graphics were found, the relative path wasn't set.
This fixes that and also improves on the error message.