### PR TITLE
generate affiliation-address training data

### DIFF
--- a/doc/training.md
+++ b/doc/training.md
@@ -19,7 +19,13 @@ For the sequence model (`delft` etc) the general workflow looks like:
 
 The training data for the sequential models follows the GROBID training data format.
 
-### Generate training data for the `segmentation` and `header` model
+### Generate training data for the sequence models
+
+Currently training data will be generated for the following models:
+
+- `segmentation`
+- `header`
+- `affiliation_address`
 
 ```bash
 python -m sciencebeam_parser.training.cli.generate_data \
@@ -27,7 +33,7 @@ python -m sciencebeam_parser.training.cli.generate_data \
     --output-path="./data/generated-training-data"
 ```
 
-Using the configured `segmentation` and `header` model to pre-annotate the training data:
+Using the configured models to pre-annotate the training data:
 
 ```bash
 python -m sciencebeam_parser.training.cli.generate_data \
@@ -36,4 +42,6 @@ python -m sciencebeam_parser.training.cli.generate_data \
     --output-path="./data/generated-training-data"
 ```
 
-Note: the `segmentation` model will be required in order to prepare the data for the `header` model.
+Note: as the models are hierachical, the parent model needs to be used
+  in order to generate data for the child model.
+  For example the `segmentation` model will be required for the `header` model.

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -31,7 +31,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     'O': ROOT_TRAINING_XML_ELEMENT_PATH,
     '<marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['marker'],
     '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]'],
-    '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]']
+    '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]'],
+    '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -37,7 +37,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode'],
     '<postBox>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postBox'],
     '<region>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'region'],
-    '<settlement>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'settlement']
+    '<settlement>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'settlement'],
+    '<country>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'country']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -34,7 +34,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]'],
     '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]'],
     '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine'],
-    '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode']
+    '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode'],
+    '<postBox>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postBox']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -33,7 +33,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]'],
     '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]'],
     '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]'],
-    '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine']
+    '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine'],
+    '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -5,9 +5,7 @@ from lxml import etree
 
 from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
 from sciencebeam_parser.document.layout_document import (
-    LayoutLine,
-    LayoutToken,
-    join_layout_tokens
+    LayoutLine
 )
 from sciencebeam_parser.document.tei.common import TEI_E
 from sciencebeam_parser.models.model import get_split_prefix_label
@@ -112,14 +110,6 @@ def get_training_xml_path_for_label(
 class AffiliationAddressTeiTrainingDataGenerator:
     DEFAULT_TEI_FILENAME_SUFFIX = '.affiliation.tei.xml'
     DEFAULT_DATA_FILENAME_SUFFIX = '.affiliation'
-
-    def write_xml_line_for_layout_tokens(
-        self,
-        xml_writer: XmlTreeWriter,
-        layout_tokens: Iterable[LayoutToken]
-    ):
-        xml_writer.append_text(join_layout_tokens(layout_tokens))
-        xml_writer.append(TEI_E('lb'))
 
     def write_xml_for_model_data_iterable(
         self,

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -152,7 +152,7 @@ class AffiliationAddressTeiTrainingDataGenerator:
                 pending_text = ''
                 xml_writer.require_path(xml_element_path)
                 xml_writer.append_text(layout_token.text)
-                pending_text = ' '
+                pending_text = layout_token.whitespace
                 prev_label = label
             xml_writer.append(TEI_E('lb'))
             pending_text = '\n'

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -94,8 +94,8 @@ def get_training_xml_path_for_label(label: Optional[str]) -> Sequence[str]:
 
 
 class AffiliationAddressTeiTrainingDataGenerator:
-    DEFAULT_TEI_FILENAME_SUFFIX = '.header.tei.xml'
-    DEFAULT_DATA_FILENAME_SUFFIX = '.header'
+    DEFAULT_TEI_FILENAME_SUFFIX = '.affiliation.tei.xml'
+    DEFAULT_DATA_FILENAME_SUFFIX = '.affiliation'
 
     def write_xml_line_for_layout_tokens(
         self,

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -30,7 +30,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<other>': ROOT_TRAINING_XML_ELEMENT_PATH,
     'O': ROOT_TRAINING_XML_ELEMENT_PATH,
     '<marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['marker'],
-    '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]']
+    '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]'],
+    '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -1,0 +1,153 @@
+import logging
+from typing import Iterable, List, Optional, Sequence
+
+from lxml import etree
+from lxml.builder import ElementMaker
+from sciencebeam_parser.models.model import get_split_prefix_label
+
+from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
+from sciencebeam_parser.document.layout_document import (
+    LayoutLine,
+    LayoutToken,
+    join_layout_tokens
+)
+from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+TEI_E = ElementMaker()
+
+
+# based on:
+# https://github.com/kermitt2/grobid/blob/0.7.0/grobid-core/src/main/java/org/grobid/core/engines/AffiliationAddressParser.java
+ROOT_TRAINING_XML_ELEMENT_PATH = [
+    'teiHeader', 'fileDesc', 'sourceDesc', 'biblStruct', 'analytic', 'author',
+    'affiliation'
+]
+TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
+    '<other>': ROOT_TRAINING_XML_ELEMENT_PATH,
+    'O': ROOT_TRAINING_XML_ELEMENT_PATH,
+    '<marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['marker'],
+    '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]']
+}
+
+
+def get_model_data_label(model_data: LayoutModelData) -> Optional[str]:
+    if isinstance(model_data, LabeledLayoutModelData):
+        return model_data.label
+    return None
+
+
+def is_same_layout_line(
+    layout_line_1: Optional[LayoutLine],
+    layout_line_2: Optional[LayoutLine]
+) -> bool:
+    assert layout_line_1 is not None
+    assert layout_line_2 is not None
+    return id(layout_line_1) == id(layout_line_2)
+
+
+def is_same_model_data_layout_line(
+    model_data_1: LayoutModelData,
+    model_data_2: LayoutModelData
+) -> bool:
+    return is_same_layout_line(model_data_1.layout_line, model_data_2.layout_line)
+
+
+def iter_group_model_data_by_line(
+    model_data_iterable: Iterable[LayoutModelData]
+) -> Iterable[Sequence[LayoutModelData]]:
+    line_model_data_list: List[LayoutModelData] = []
+    for model_data in model_data_iterable:
+        if not line_model_data_list:
+            line_model_data_list.append(model_data)
+            continue
+        previous_model_data = line_model_data_list[-1]
+        if is_same_model_data_layout_line(
+            model_data,
+            previous_model_data
+        ):
+            LOGGER.debug('same line: %r - %r', model_data, previous_model_data)
+            line_model_data_list.append(model_data)
+            continue
+        yield line_model_data_list
+        line_model_data_list = [model_data]
+    if line_model_data_list:
+        yield line_model_data_list
+
+
+def get_default_note_type_for_label(label: str) -> str:
+    return label.strip('<>')
+
+
+def get_training_xml_path_for_label(label: Optional[str]) -> Sequence[str]:
+    if not label:
+        return ROOT_TRAINING_XML_ELEMENT_PATH
+    training_xml_path = TRAINING_XML_ELEMENT_PATH_BY_LABEL.get(label or '')
+    if not training_xml_path:
+        note_type = get_default_note_type_for_label(label)
+        LOGGER.info('label not mapped, creating note: %r', label)
+        training_xml_path = ROOT_TRAINING_XML_ELEMENT_PATH + [f'note[@type="{note_type}"]']
+    return training_xml_path
+
+
+class AffiliationAddressTeiTrainingDataGenerator:
+    DEFAULT_TEI_FILENAME_SUFFIX = '.header.tei.xml'
+    DEFAULT_DATA_FILENAME_SUFFIX = '.header'
+
+    def write_xml_line_for_layout_tokens(
+        self,
+        xml_writer: XmlTreeWriter,
+        layout_tokens: Iterable[LayoutToken]
+    ):
+        xml_writer.append_text(join_layout_tokens(layout_tokens))
+        xml_writer.append(TEI_E('lb'))
+
+    def write_xml_for_model_data_iterable(
+        self,
+        xml_writer: XmlTreeWriter,
+        model_data_iterable: Iterable[LayoutModelData]
+    ):
+        default_path = xml_writer.current_path
+        pending_text = ''
+        for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
+            for model_data in line_model_data_list:
+                layout_token = model_data.layout_token
+                assert layout_token is not None
+                prefixed_label = get_model_data_label(model_data)
+                prefix, label = get_split_prefix_label(prefixed_label or '')
+                xml_element_path = get_training_xml_path_for_label(label)
+                LOGGER.debug('label: %r (%r: %r)', label, prefix, xml_element_path)
+                if xml_writer.current_path != xml_element_path:
+                    xml_writer.require_path(default_path)
+                if prefix == 'B':
+                    xml_writer.require_path(xml_element_path[:-1])
+                xml_writer.append_text(pending_text)
+                pending_text = ''
+                xml_writer.require_path(xml_element_path)
+                xml_writer.append_text(layout_token.text)
+                pending_text = ' '
+            xml_writer.append(TEI_E('lb'))
+            pending_text = '\n'
+        xml_writer.require_path(default_path)
+        xml_writer.append_text(pending_text)
+
+    def _get_xml_writer(self) -> XmlTreeWriter:
+        return XmlTreeWriter(
+            TEI_E('tei'),
+            element_maker=TEI_E
+        )
+
+    def get_training_tei_xml_for_model_data_iterable(
+        self,
+        model_data_iterable: Iterable[LayoutModelData]
+    ) -> etree.ElementBase:
+        xml_writer = self._get_xml_writer()
+        xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH)
+        self.write_xml_for_model_data_iterable(
+            xml_writer,
+            model_data_iterable=model_data_iterable
+        )
+        return xml_writer.root

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -2,8 +2,6 @@ import logging
 from typing import Iterable, List, Optional, Sequence
 
 from lxml import etree
-from lxml.builder import ElementMaker
-from sciencebeam_parser.models.model import get_split_prefix_label
 
 from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
 from sciencebeam_parser.document.layout_document import (
@@ -11,13 +9,12 @@ from sciencebeam_parser.document.layout_document import (
     LayoutToken,
     join_layout_tokens
 )
+from sciencebeam_parser.document.tei.common import TEI_E
+from sciencebeam_parser.models.model import get_split_prefix_label
 from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-TEI_E = ElementMaker()
 
 
 # based on:

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -32,7 +32,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['marker'],
     '<institution>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="institution"]'],
     '<department>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="department"]'],
-    '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]']
+    '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]'],
+    '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -1,15 +1,9 @@
 import logging
-from typing import Iterable, List, Optional, Sequence
 
-from lxml import etree
-
-from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
-from sciencebeam_parser.document.layout_document import (
-    LayoutLine
-)
 from sciencebeam_parser.document.tei.common import TEI_E
-from sciencebeam_parser.models.model import get_split_prefix_label
-from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
+from sciencebeam_parser.models.training_data import (
+    AbstractTeiTrainingDataGenerator
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -17,12 +11,11 @@ LOGGER = logging.getLogger(__name__)
 
 # based on:
 # https://github.com/kermitt2/grobid/blob/0.7.0/grobid-core/src/main/java/org/grobid/core/engines/AffiliationAddressParser.java
+
 ROOT_TRAINING_XML_ELEMENT_PATH = [
     'teiHeader', 'fileDesc', 'sourceDesc', 'biblStruct', 'analytic', 'author',
     'affiliation'
 ]
-
-OTHER_LABELS = {'<other>', 'O'}
 
 TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['marker'],
@@ -37,143 +30,14 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<country>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'country']
 }
 
-TRAINING_XML_ELEMENT_PATHS = {
-    tuple(value)
-    for value in TRAINING_XML_ELEMENT_PATH_BY_LABEL.values()
-}
 
-
-def get_model_data_label(model_data: LayoutModelData) -> Optional[str]:
-    if isinstance(model_data, LabeledLayoutModelData):
-        return model_data.label
-    return None
-
-
-def is_same_layout_line(
-    layout_line_1: Optional[LayoutLine],
-    layout_line_2: Optional[LayoutLine]
-) -> bool:
-    assert layout_line_1 is not None
-    assert layout_line_2 is not None
-    return id(layout_line_1) == id(layout_line_2)
-
-
-def is_same_model_data_layout_line(
-    model_data_1: LayoutModelData,
-    model_data_2: LayoutModelData
-) -> bool:
-    return is_same_layout_line(model_data_1.layout_line, model_data_2.layout_line)
-
-
-def iter_group_model_data_by_line(
-    model_data_iterable: Iterable[LayoutModelData]
-) -> Iterable[Sequence[LayoutModelData]]:
-    line_model_data_list: List[LayoutModelData] = []
-    for model_data in model_data_iterable:
-        if not line_model_data_list:
-            line_model_data_list.append(model_data)
-            continue
-        previous_model_data = line_model_data_list[-1]
-        if is_same_model_data_layout_line(
-            model_data,
-            previous_model_data
-        ):
-            LOGGER.debug('same line: %r - %r', model_data, previous_model_data)
-            line_model_data_list.append(model_data)
-            continue
-        yield line_model_data_list
-        line_model_data_list = [model_data]
-    if line_model_data_list:
-        yield line_model_data_list
-
-
-def get_default_note_type_for_label(label: str) -> str:
-    return label.strip('<>')
-
-
-def get_training_xml_path_for_label(
-    label: Optional[str],
-    current_path: Sequence[str]
-) -> Sequence[str]:
-    if not label or label in OTHER_LABELS:
-        if tuple(current_path) in TRAINING_XML_ELEMENT_PATHS:
-            return current_path[:-1]
-        return current_path
-    training_xml_path = TRAINING_XML_ELEMENT_PATH_BY_LABEL.get(label or '')
-    if not training_xml_path:
-        note_type = get_default_note_type_for_label(label)
-        LOGGER.info('label not mapped, creating note: %r', label)
-        training_xml_path = ROOT_TRAINING_XML_ELEMENT_PATH + [f'note[@type="{note_type}"]']
-    return training_xml_path
-
-
-class AffiliationAddressTeiTrainingDataGenerator:
+class AffiliationAddressTeiTrainingDataGenerator(AbstractTeiTrainingDataGenerator):
     DEFAULT_TEI_FILENAME_SUFFIX = '.affiliation.tei.xml'
     DEFAULT_DATA_FILENAME_SUFFIX = '.affiliation'
 
-    def write_xml_for_model_data_iterable(
-        self,
-        xml_writer: XmlTreeWriter,
-        model_data_iterable: Iterable[LayoutModelData]
-    ):
-        default_path = xml_writer.current_path
-        pending_whitespace = ''
-        prev_label: str = ''
-        for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
-            for model_data in line_model_data_list:
-                layout_token = model_data.layout_token
-                assert layout_token is not None
-                prefixed_label = get_model_data_label(model_data)
-                prefix, label = get_split_prefix_label(prefixed_label or '')
-                xml_element_path = get_training_xml_path_for_label(
-                    label,
-                    current_path=xml_writer.current_path
-                )
-                LOGGER.debug('label: %r (%r: %r)', label, prefix, xml_element_path)
-                if (
-                    prev_label not in OTHER_LABELS
-                    and pending_whitespace
-                    and xml_writer.current_path != xml_element_path
-                ):
-                    xml_writer.require_path(xml_writer.current_path[:-1])
-                elif prefix == 'B' and label not in OTHER_LABELS:
-                    xml_writer.require_path(xml_element_path[:-1])
-                xml_writer.append_text(pending_whitespace)
-                pending_whitespace = ''
-                xml_writer.require_path(xml_element_path)
-                xml_writer.append_text(layout_token.text)
-                pending_whitespace = layout_token.whitespace
-                prev_label = label
-            xml_writer.append(TEI_E('lb'))
-            pending_whitespace = '\n'
-        xml_writer.require_path(default_path)
-        xml_writer.append_text(pending_whitespace)
-
-    def _get_xml_writer(self) -> XmlTreeWriter:
-        return XmlTreeWriter(
-            TEI_E('tei'),
+    def __init__(self):
+        super().__init__(
+            root_training_xml_element_path=ROOT_TRAINING_XML_ELEMENT_PATH,
+            training_xml_element_path_by_label=TRAINING_XML_ELEMENT_PATH_BY_LABEL,
             element_maker=TEI_E
-        )
-
-    def get_training_tei_xml_for_multiple_model_data_iterables(
-        self,
-        model_data_iterables: Iterable[Iterable[LayoutModelData]]
-    ) -> etree.ElementBase:
-        xml_writer = self._get_xml_writer()
-        xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH[:-1])
-        for model_data_iterable in model_data_iterables:
-            xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH[:-1])
-            xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH)
-            self.write_xml_for_model_data_iterable(
-                xml_writer,
-                model_data_iterable=model_data_iterable
-            )
-        return xml_writer.root
-
-    def get_training_tei_xml_for_model_data_iterable(
-        self,
-        model_data_iterable: Iterable[LayoutModelData]
-    ) -> etree.ElementBase:
-        return self.get_training_tei_xml_for_multiple_model_data_iterables(
-            [model_data_iterable]
         )

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -35,7 +35,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<laboratory>': ROOT_TRAINING_XML_ELEMENT_PATH + ['orgName[@type="laboratory"]'],
     '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine'],
     '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode'],
-    '<postBox>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postBox']
+    '<postBox>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postBox'],
+    '<region>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'region']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -127,7 +127,7 @@ class AffiliationAddressTeiTrainingDataGenerator:
         model_data_iterable: Iterable[LayoutModelData]
     ):
         default_path = xml_writer.current_path
-        pending_text = ''
+        pending_whitespace = ''
         prev_label: str = ''
         for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
             for model_data in line_model_data_list:
@@ -142,22 +142,22 @@ class AffiliationAddressTeiTrainingDataGenerator:
                 LOGGER.debug('label: %r (%r: %r)', label, prefix, xml_element_path)
                 if (
                     prev_label not in OTHER_LABELS
-                    and pending_text
+                    and pending_whitespace
                     and xml_writer.current_path != xml_element_path
                 ):
                     xml_writer.require_path(xml_writer.current_path[:-1])
                 elif prefix == 'B' and label not in OTHER_LABELS:
                     xml_writer.require_path(xml_element_path[:-1])
-                xml_writer.append_text(pending_text)
-                pending_text = ''
+                xml_writer.append_text(pending_whitespace)
+                pending_whitespace = ''
                 xml_writer.require_path(xml_element_path)
                 xml_writer.append_text(layout_token.text)
-                pending_text = layout_token.whitespace
+                pending_whitespace = layout_token.whitespace
                 prev_label = label
             xml_writer.append(TEI_E('lb'))
-            pending_text = '\n'
+            pending_whitespace = '\n'
         xml_writer.require_path(default_path)
-        xml_writer.append_text(pending_text)
+        xml_writer.append_text(pending_whitespace)
 
     def _get_xml_writer(self) -> XmlTreeWriter:
         return XmlTreeWriter(

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -36,7 +36,8 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<addrLine>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'addrLine'],
     '<postCode>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postCode'],
     '<postBox>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'postBox'],
-    '<region>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'region']
+    '<region>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'region'],
+    '<settlement>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address', 'settlement']
 }
 
 

--- a/sciencebeam_parser/models/affiliation_address/training_data.py
+++ b/sciencebeam_parser/models/affiliation_address/training_data.py
@@ -140,14 +140,25 @@ class AffiliationAddressTeiTrainingDataGenerator:
             element_maker=TEI_E
         )
 
+    def get_training_tei_xml_for_multiple_model_data_iterables(
+        self,
+        model_data_iterables: Iterable[Iterable[LayoutModelData]]
+    ) -> etree.ElementBase:
+        xml_writer = self._get_xml_writer()
+        xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH[:-1])
+        for model_data_iterable in model_data_iterables:
+            xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH[:-1])
+            xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH)
+            self.write_xml_for_model_data_iterable(
+                xml_writer,
+                model_data_iterable=model_data_iterable
+            )
+        return xml_writer.root
+
     def get_training_tei_xml_for_model_data_iterable(
         self,
         model_data_iterable: Iterable[LayoutModelData]
     ) -> etree.ElementBase:
-        xml_writer = self._get_xml_writer()
-        xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH)
-        self.write_xml_for_model_data_iterable(
-            xml_writer,
-            model_data_iterable=model_data_iterable
+        return self.get_training_tei_xml_for_multiple_model_data_iterables(
+            [model_data_iterable]
         )
-        return xml_writer.root

--- a/sciencebeam_parser/models/header/training_data.py
+++ b/sciencebeam_parser/models/header/training_data.py
@@ -130,7 +130,7 @@ class HeaderTeiTrainingDataGenerator:
         model_data_iterable: Iterable[LayoutModelData]
     ):
         default_path = xml_writer.current_path
-        pending_text = ''
+        pending_whitespace = ''
         for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
             for model_data in line_model_data_list:
                 layout_token = model_data.layout_token
@@ -143,15 +143,15 @@ class HeaderTeiTrainingDataGenerator:
                     xml_writer.require_path(default_path)
                 if prefix == 'B':
                     xml_writer.require_path(xml_element_path[:-1])
-                xml_writer.append_text(pending_text)
-                pending_text = ''
+                xml_writer.append_text(pending_whitespace)
+                pending_whitespace = ''
                 xml_writer.require_path(xml_element_path)
                 xml_writer.append_text(layout_token.text)
-                pending_text = ' '
+                pending_whitespace = layout_token.whitespace
             xml_writer.append(TEI_E('lb'))
-            pending_text = '\n'
+            pending_whitespace = '\n'
         xml_writer.require_path(default_path)
-        xml_writer.append_text(pending_text)
+        xml_writer.append_text(pending_whitespace)
 
     def _get_xml_writer(self) -> XmlTreeWriter:
         return XmlTreeWriter(

--- a/sciencebeam_parser/models/header/training_data.py
+++ b/sciencebeam_parser/models/header/training_data.py
@@ -1,15 +1,10 @@
 import logging
-from typing import Iterable, List, Optional, Sequence
 
-from lxml import etree
 from lxml.builder import ElementMaker
-from sciencebeam_parser.models.model import get_split_prefix_label
 
-from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
-from sciencebeam_parser.document.layout_document import (
-    LayoutLine
+from sciencebeam_parser.models.training_data import (
+    AbstractTeiTrainingDataGenerator
 )
-from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
 
 
 LOGGER = logging.getLogger(__name__)
@@ -21,9 +16,8 @@ TEI_E = ElementMaker()
 # based on:
 # https://github.com/kermitt2/grobid/blob/0.7.0/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
 ROOT_TRAINING_XML_ELEMENT_PATH = ['text', 'front']
+
 TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
-    '<other>': ROOT_TRAINING_XML_ELEMENT_PATH,
-    'O': ROOT_TRAINING_XML_ELEMENT_PATH,
     '<title>': ROOT_TRAINING_XML_ELEMENT_PATH + ['docTitle', 'titlePart'],
     '<author>': ROOT_TRAINING_XML_ELEMENT_PATH + ['byline', 'docAuthor'],
     '<location>': ROOT_TRAINING_XML_ELEMENT_PATH + ['address'],
@@ -51,112 +45,13 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
 }
 
 
-def get_model_data_label(model_data: LayoutModelData) -> Optional[str]:
-    if isinstance(model_data, LabeledLayoutModelData):
-        return model_data.label
-    return None
-
-
-def is_same_layout_line(
-    layout_line_1: Optional[LayoutLine],
-    layout_line_2: Optional[LayoutLine]
-) -> bool:
-    assert layout_line_1 is not None
-    assert layout_line_2 is not None
-    return id(layout_line_1) == id(layout_line_2)
-
-
-def is_same_model_data_layout_line(
-    model_data_1: LayoutModelData,
-    model_data_2: LayoutModelData
-) -> bool:
-    return is_same_layout_line(model_data_1.layout_line, model_data_2.layout_line)
-
-
-def iter_group_model_data_by_line(
-    model_data_iterable: Iterable[LayoutModelData]
-) -> Iterable[Sequence[LayoutModelData]]:
-    line_model_data_list: List[LayoutModelData] = []
-    for model_data in model_data_iterable:
-        if not line_model_data_list:
-            line_model_data_list.append(model_data)
-            continue
-        previous_model_data = line_model_data_list[-1]
-        if is_same_model_data_layout_line(
-            model_data,
-            previous_model_data
-        ):
-            LOGGER.debug('same line: %r - %r', model_data, previous_model_data)
-            line_model_data_list.append(model_data)
-            continue
-        yield line_model_data_list
-        line_model_data_list = [model_data]
-    if line_model_data_list:
-        yield line_model_data_list
-
-
-def get_default_note_type_for_label(label: str) -> str:
-    return label.strip('<>')
-
-
-def get_training_xml_path_for_label(label: Optional[str]) -> Sequence[str]:
-    if not label:
-        return ROOT_TRAINING_XML_ELEMENT_PATH
-    training_xml_path = TRAINING_XML_ELEMENT_PATH_BY_LABEL.get(label or '')
-    if not training_xml_path:
-        note_type = get_default_note_type_for_label(label)
-        LOGGER.info('label not mapped, creating note: %r', label)
-        training_xml_path = ROOT_TRAINING_XML_ELEMENT_PATH + [f'note[@type="{note_type}"]']
-    return training_xml_path
-
-
-class HeaderTeiTrainingDataGenerator:
+class HeaderTeiTrainingDataGenerator(AbstractTeiTrainingDataGenerator):
     DEFAULT_TEI_FILENAME_SUFFIX = '.header.tei.xml'
     DEFAULT_DATA_FILENAME_SUFFIX = '.header'
 
-    def write_xml_for_model_data_iterable(
-        self,
-        xml_writer: XmlTreeWriter,
-        model_data_iterable: Iterable[LayoutModelData]
-    ):
-        default_path = xml_writer.current_path
-        pending_whitespace = ''
-        for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
-            for model_data in line_model_data_list:
-                layout_token = model_data.layout_token
-                assert layout_token is not None
-                prefixed_label = get_model_data_label(model_data)
-                prefix, label = get_split_prefix_label(prefixed_label or '')
-                xml_element_path = get_training_xml_path_for_label(label)
-                LOGGER.debug('label: %r (%r: %r)', label, prefix, xml_element_path)
-                if xml_writer.current_path != xml_element_path:
-                    xml_writer.require_path(default_path)
-                if prefix == 'B':
-                    xml_writer.require_path(xml_element_path[:-1])
-                xml_writer.append_text(pending_whitespace)
-                pending_whitespace = ''
-                xml_writer.require_path(xml_element_path)
-                xml_writer.append_text(layout_token.text)
-                pending_whitespace = layout_token.whitespace
-            xml_writer.append(TEI_E('lb'))
-            pending_whitespace = '\n'
-        xml_writer.require_path(default_path)
-        xml_writer.append_text(pending_whitespace)
-
-    def _get_xml_writer(self) -> XmlTreeWriter:
-        return XmlTreeWriter(
-            TEI_E('tei'),
+    def __init__(self):
+        super().__init__(
+            root_training_xml_element_path=ROOT_TRAINING_XML_ELEMENT_PATH,
+            training_xml_element_path_by_label=TRAINING_XML_ELEMENT_PATH_BY_LABEL,
             element_maker=TEI_E
         )
-
-    def get_training_tei_xml_for_model_data_iterable(
-        self,
-        model_data_iterable: Iterable[LayoutModelData]
-    ) -> etree.ElementBase:
-        xml_writer = self._get_xml_writer()
-        xml_writer.require_path(ROOT_TRAINING_XML_ELEMENT_PATH)
-        self.write_xml_for_model_data_iterable(
-            xml_writer,
-            model_data_iterable=model_data_iterable
-        )
-        return xml_writer.root

--- a/sciencebeam_parser/models/header/training_data.py
+++ b/sciencebeam_parser/models/header/training_data.py
@@ -7,9 +7,7 @@ from sciencebeam_parser.models.model import get_split_prefix_label
 
 from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
 from sciencebeam_parser.document.layout_document import (
-    LayoutLine,
-    LayoutToken,
-    join_layout_tokens
+    LayoutLine
 )
 from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
 
@@ -115,14 +113,6 @@ def get_training_xml_path_for_label(label: Optional[str]) -> Sequence[str]:
 class HeaderTeiTrainingDataGenerator:
     DEFAULT_TEI_FILENAME_SUFFIX = '.header.tei.xml'
     DEFAULT_DATA_FILENAME_SUFFIX = '.header'
-
-    def write_xml_line_for_layout_tokens(
-        self,
-        xml_writer: XmlTreeWriter,
-        layout_tokens: Iterable[LayoutToken]
-    ):
-        xml_writer.append_text(join_layout_tokens(layout_tokens))
-        xml_writer.append(TEI_E('lb'))
 
     def write_xml_for_model_data_iterable(
         self,

--- a/sciencebeam_parser/models/model.py
+++ b/sciencebeam_parser/models/model.py
@@ -212,14 +212,11 @@ def iter_labeled_layout_token_for_layout_model_label(
 def iter_data_lines_for_model_data_iterables(
     model_data_iterables: Iterable[Iterable[LayoutModelData]]
 ) -> Iterable[str]:
-    data_lines = []
     for index, model_data_list in enumerate(model_data_iterables):
         if index > 0:
-            data_lines.append('')
-        data_lines.extend(
-            (model_data.data_line for model_data in model_data_list)
-        )
-    return data_lines
+            yield ''
+        for model_data in model_data_list:
+            yield model_data.data_line
 
 
 class Model(ABC, Preloadable):

--- a/sciencebeam_parser/models/model.py
+++ b/sciencebeam_parser/models/model.py
@@ -16,6 +16,7 @@ from sciencebeam_parser.document.layout_document import (
 from sciencebeam_parser.models.data import (
     AppFeaturesContext,
     DocumentFeaturesContext,
+    LayoutModelData,
     ModelDataGenerator
 )
 from sciencebeam_parser.models.extract import ModelSemanticExtractor
@@ -208,6 +209,19 @@ def iter_labeled_layout_token_for_layout_model_label(
         )
 
 
+def iter_data_lines_for_model_data_iterables(
+    model_data_iterables: Iterable[Iterable[LayoutModelData]]
+) -> Iterable[str]:
+    data_lines = []
+    for index, model_data_list in enumerate(model_data_iterables):
+        if index > 0:
+            data_lines.append('')
+        data_lines.extend(
+            (model_data.data_line for model_data in model_data_list)
+        )
+    return data_lines
+
+
 class Model(ABC, Preloadable):
     def __init__(
         self,
@@ -320,13 +334,9 @@ class Model(ABC, Preloadable):
             ))
             for layout_document in layout_documents
         ]
-        data_lines = []
-        for index, model_data_list in enumerate(model_data_lists):
-            if index > 0:
-                data_lines.append('')
-            data_lines.extend(
-                (model_data.data_line for model_data in model_data_list)
-            )
+        data_lines = list(iter_data_lines_for_model_data_iterables(
+            model_data_lists
+        ))
         texts, features = load_data_crf_lines(data_lines)
         texts = texts.tolist()
         tag_result = self.predict_labels(

--- a/sciencebeam_parser/models/segmentation/training_data.py
+++ b/sciencebeam_parser/models/segmentation/training_data.py
@@ -108,7 +108,7 @@ class SegmentationTeiTrainingDataGenerator:
         model_data_iterable: Iterable[LayoutModelData]
     ):
         default_path = xml_writer.current_path
-        pending_text = ''
+        pending_whitespace = ''
         for model_data in model_data_iterable:
             prefixed_label = get_model_data_label(model_data)
             _prefix, label = get_split_prefix_label(prefixed_label or '')
@@ -116,8 +116,8 @@ class SegmentationTeiTrainingDataGenerator:
             LOGGER.debug('label: %r (%r)', label, xml_element_path)
             if xml_writer.current_path != xml_element_path:
                 xml_writer.require_path(default_path)
-            xml_writer.append_text(pending_text)
-            pending_text = ''
+            xml_writer.append_text(pending_whitespace)
+            pending_whitespace = ''
             xml_writer.require_path(xml_element_path)
             for layout_line in iter_layout_lines_from_layout_tokens(
                 iter_tokens_from_model_data(model_data)
@@ -126,9 +126,9 @@ class SegmentationTeiTrainingDataGenerator:
                     xml_writer,
                     layout_line.tokens
                 )
-                pending_text = '\n'
+                pending_whitespace = '\n'
         xml_writer.require_path(default_path)
-        xml_writer.append_text(pending_text)
+        xml_writer.append_text(pending_whitespace)
 
     def _get_training_tei_xml_for_children(
         self,

--- a/sciencebeam_parser/models/training_data.py
+++ b/sciencebeam_parser/models/training_data.py
@@ -1,0 +1,169 @@
+import logging
+from typing import Iterable, List, Mapping, Optional, Sequence
+
+from lxml import etree
+from lxml.builder import ElementMaker
+
+from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
+from sciencebeam_parser.document.layout_document import (
+    LayoutLine
+)
+from sciencebeam_parser.models.model import get_split_prefix_label
+from sciencebeam_parser.models.data import LabeledLayoutModelData, LayoutModelData
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+OTHER_LABELS = {'<other>', 'O'}
+
+
+def get_model_data_label(model_data: LayoutModelData) -> Optional[str]:
+    if isinstance(model_data, LabeledLayoutModelData):
+        return model_data.label
+    return None
+
+
+def is_same_layout_line(
+    layout_line_1: Optional[LayoutLine],
+    layout_line_2: Optional[LayoutLine]
+) -> bool:
+    assert layout_line_1 is not None
+    assert layout_line_2 is not None
+    return id(layout_line_1) == id(layout_line_2)
+
+
+def is_same_model_data_layout_line(
+    model_data_1: LayoutModelData,
+    model_data_2: LayoutModelData
+) -> bool:
+    return is_same_layout_line(model_data_1.layout_line, model_data_2.layout_line)
+
+
+def iter_group_model_data_by_line(
+    model_data_iterable: Iterable[LayoutModelData]
+) -> Iterable[Sequence[LayoutModelData]]:
+    line_model_data_list: List[LayoutModelData] = []
+    for model_data in model_data_iterable:
+        if not line_model_data_list:
+            line_model_data_list.append(model_data)
+            continue
+        previous_model_data = line_model_data_list[-1]
+        if is_same_model_data_layout_line(
+            model_data,
+            previous_model_data
+        ):
+            LOGGER.debug('same line: %r - %r', model_data, previous_model_data)
+            line_model_data_list.append(model_data)
+            continue
+        yield line_model_data_list
+        line_model_data_list = [model_data]
+    if line_model_data_list:
+        yield line_model_data_list
+
+
+def get_default_note_type_for_label(label: str) -> str:
+    return label.strip('<>')
+
+
+class AbstractTeiTrainingDataGenerator:
+    def __init__(
+        self,
+        root_training_xml_element_path: Sequence[str],
+        training_xml_element_path_by_label: Mapping[str, Sequence[str]],
+        element_maker: ElementMaker
+    ):
+        self.root_training_xml_element_path = root_training_xml_element_path
+        self.root_parent_training_xml_element_path = root_training_xml_element_path[:-1]
+        self.training_xml_element_path_by_label = training_xml_element_path_by_label
+        self._training_xml_element_paths = {
+            tuple(value)
+            for label, value in training_xml_element_path_by_label.items()
+            if label not in OTHER_LABELS
+        }
+        self.element_maker = element_maker
+
+    def get_training_xml_path_for_label(
+        self,
+        label: Optional[str],
+        current_path: Sequence[str]
+    ) -> Sequence[str]:
+        if not label or label in OTHER_LABELS:
+            if tuple(current_path) in self._training_xml_element_paths:
+                return current_path[:-1]
+            return current_path
+        training_xml_path = self.training_xml_element_path_by_label.get(label or '')
+        if not training_xml_path:
+            note_type = get_default_note_type_for_label(label)
+            LOGGER.info('label not mapped, creating note: %r', label)
+            training_xml_path = (
+                list(self.root_training_xml_element_path) + [f'note[@type="{note_type}"]']
+            )
+        return training_xml_path
+
+    def write_xml_for_model_data_iterable(
+        self,
+        xml_writer: XmlTreeWriter,
+        model_data_iterable: Iterable[LayoutModelData]
+    ):
+        default_path = xml_writer.current_path
+        pending_whitespace = ''
+        prev_label: str = ''
+        for line_model_data_list in iter_group_model_data_by_line(model_data_iterable):
+            for model_data in line_model_data_list:
+                layout_token = model_data.layout_token
+                assert layout_token is not None
+                prefixed_label = get_model_data_label(model_data)
+                prefix, label = get_split_prefix_label(prefixed_label or '')
+                xml_element_path = self.get_training_xml_path_for_label(
+                    label,
+                    current_path=xml_writer.current_path
+                )
+                LOGGER.debug('label: %r (%r: %r)', label, prefix, xml_element_path)
+                if (
+                    prev_label not in OTHER_LABELS
+                    and pending_whitespace
+                    and xml_writer.current_path != xml_element_path
+                ):
+                    xml_writer.require_path(xml_writer.current_path[:-1])
+                elif prefix == 'B' and label not in OTHER_LABELS:
+                    xml_writer.require_path(xml_element_path[:-1])
+                xml_writer.append_text(pending_whitespace)
+                pending_whitespace = ''
+                xml_writer.require_path(xml_element_path)
+                xml_writer.append_text(layout_token.text)
+                pending_whitespace = layout_token.whitespace
+                prev_label = label
+            xml_writer.append(self.element_maker('lb'))
+            pending_whitespace = '\n'
+        xml_writer.require_path(default_path)
+        xml_writer.append_text(pending_whitespace)
+
+    def _get_xml_writer(self) -> XmlTreeWriter:
+        return XmlTreeWriter(
+            self.element_maker('tei'),
+            element_maker=self.element_maker
+        )
+
+    def get_training_tei_xml_for_multiple_model_data_iterables(
+        self,
+        model_data_iterables: Iterable[Iterable[LayoutModelData]]
+    ) -> etree.ElementBase:
+        xml_writer = self._get_xml_writer()
+        xml_writer.require_path(self.root_parent_training_xml_element_path)
+        for model_data_iterable in model_data_iterables:
+            xml_writer.require_path(self.root_parent_training_xml_element_path)
+            xml_writer.require_path(self.root_training_xml_element_path)
+            self.write_xml_for_model_data_iterable(
+                xml_writer,
+                model_data_iterable=model_data_iterable
+            )
+        return xml_writer.root
+
+    def get_training_tei_xml_for_model_data_iterable(
+        self,
+        model_data_iterable: Iterable[LayoutModelData]
+    ) -> etree.ElementBase:
+        return self.get_training_tei_xml_for_multiple_model_data_iterables(
+            [model_data_iterable]
+        )

--- a/sciencebeam_parser/training/cli/generate_data.py
+++ b/sciencebeam_parser/training/cli/generate_data.py
@@ -67,6 +67,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         action='store_true',
         help='Use configured models to pre-annotate training data'
     )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug logging'
+    )
     return parser.parse_args(argv)
 
 
@@ -494,6 +499,9 @@ def run(args: argparse.Namespace):
 def main(argv: Optional[List[str]] = None):
     LOGGER.debug('argv: %r', argv)
     args = parse_args(argv)
+    if args.debug:
+        for name in [__name__, 'sciencebeam_parser', 'sciencebeam_trainer_delft']:
+            logging.getLogger(name).setLevel('DEBUG')
     run(args)
 
 

--- a/sciencebeam_parser/training/cli/generate_data.py
+++ b/sciencebeam_parser/training/cli/generate_data.py
@@ -94,6 +94,7 @@ def get_labeled_model_data_list_list(
     LOGGER.debug('tag_result: %r', tag_result)
     LOGGER.debug('model_data_list_list[0]: %d', len(model_data_list_list[0]))
     LOGGER.debug('tag_result[0]: %d', len(tag_result[0]))
+    assert len(tag_result) == len(model_data_list_list)
     assert len(tag_result[0]) == len(model_data_list_list[0])
     labeled_model_data_list_list = [
         [
@@ -101,9 +102,9 @@ def get_labeled_model_data_list_list(
                 model_data,
                 label=label
             )
-            for model_data, (_, label) in zip(model_data_list, tag_result[0])
+            for model_data, (_, label) in zip(model_data_list, doc_tag_result)
         ]
-        for model_data_list in model_data_list_list
+        for model_data_list, doc_tag_result in zip(model_data_list_list, tag_result)
     ]
     return labeled_model_data_list_list
 

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -9,6 +9,7 @@ from sciencebeam_parser.document.layout_document import (
     LayoutLine,
     LayoutLineDescriptor
 )
+from sciencebeam_parser.document.tei.common import get_tei_xpath_text_content_list, tei_xpath
 from sciencebeam_parser.models.data import (
     DEFAULT_DOCUMENT_FEATURES_CONTEXT,
     LabeledLayoutModelData,
@@ -18,7 +19,7 @@ from sciencebeam_parser.models.affiliation_address.data import AffiliationAddres
 from sciencebeam_parser.models.affiliation_address.training_data import (
     AffiliationAddressTeiTrainingDataGenerator
 )
-from sciencebeam_parser.utils.xml import get_text_content, get_text_content_list
+from sciencebeam_parser.utils.xml import get_text_content
 
 
 LOGGER = logging.getLogger(__name__)
@@ -29,7 +30,8 @@ TEXT_2 = 'this is text 2'
 
 
 AFFILIATION_XPATH = (
-    'teiHeader/fileDesc/sourceDesc/biblStruct/analytic/author/affiliation'
+    'tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:biblStruct'
+    '/tei:analytic/tei:author/tei:affiliation'
 )
 
 
@@ -102,7 +104,7 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             get_model_data_list_for_layout_document(layout_document)
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
         assert get_text_content(aff_nodes[0]).rstrip() == TEXT_1
 
@@ -115,7 +117,7 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
             get_model_data_list_for_layout_document(layout_document)
         )
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
         assert get_text_content(aff_nodes[0]).rstrip() == '\n'.join([TEXT_1, TEXT_2])
 
@@ -128,9 +130,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
             get_model_data_list_for_layout_document(layout_document)
         )
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        lb_nodes = aff_nodes[0].xpath('lb')
+        lb_nodes = tei_xpath(aff_nodes[0], 'tei:lb')
         assert len(lb_nodes) == 2
         assert lb_nodes[0].getparent().text == TEXT_1
         assert lb_nodes[0].tail == '\n' + TEXT_2
@@ -149,9 +151,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             model_data_iterable
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        lb_nodes = aff_nodes[0].xpath('lb')
+        lb_nodes = tei_xpath(aff_nodes[0], 'tei:lb')
         assert len(lb_nodes) == 2
         assert lb_nodes[0].getparent().text == TEXT_1
         assert lb_nodes[0].tail == '\n' + TEXT_2
@@ -169,13 +171,13 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             labeled_model_data_list
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./marker')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:marker'
         ) == [TEXT_1]
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="institution"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="institution"]'
         ) == [TEXT_2]
         assert get_text_content(aff_nodes[0]) == f'{TEXT_1}\n{TEXT_2}\n'
 
@@ -205,40 +207,40 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             labeled_model_data_list
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./marker')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:marker'
         ) == ['Marker 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="institution"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="institution"]'
         ) == ['Institution 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="department"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="department"]'
         ) == ['Department 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="laboratory"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="laboratory"]'
         ) == ['Laboratory 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/addrLine')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:addrLine'
         ) == ['AddrLine 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/postCode')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:postCode'
         ) == ['PostCode 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/postBox')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:postBox'
         ) == ['PostBox 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/region')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:region'
         ) == ['Region 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/settlement')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:settlement'
         ) == ['Settlement 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address/country')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address/tei:country'
         ) == ['Country 1']
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./address')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:address'
         ) == ['\n,\n'.join([
             'AddrLine 1', 'PostCode 1', 'PostBox 1', 'Region 1', 'Settlement 1', 'Country 1'
         ])]
@@ -255,10 +257,10 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             labeled_model_data_list
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./note[@type="unknown"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:note[@type="unknown"]'
         ) == [TEXT_1]
         assert get_text_content(aff_nodes[0]) == f'{TEXT_1}\n'
 
@@ -275,10 +277,10 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             labeled_model_data_list
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 1
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="institution"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="institution"]'
         ) == [TEXT_1, TEXT_2]
         assert get_text_content(aff_nodes[0]) == f'{TEXT_1}\n{TEXT_2}\n'
 
@@ -298,11 +300,11 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             labeled_model_data_list_list
         )
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
         assert len(aff_nodes) == 2
-        assert get_text_content_list(
-            aff_nodes[0].xpath('./orgName[@type="institution"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[0], './tei:orgName[@type="institution"]'
         ) == [TEXT_1]
-        assert get_text_content_list(
-            aff_nodes[1].xpath('./orgName[@type="institution"]')
+        assert get_tei_xpath_text_content_list(
+            aff_nodes[1], './tei:orgName[@type="institution"]'
         ) == [TEXT_2]

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -84,6 +84,16 @@ def get_layout_line_for_text(text: str, line_id: int) -> LayoutLine:
     )
 
 
+class ModuleState:
+    line_id: int = 1
+
+
+def get_next_layout_line_for_text(text: str) -> LayoutLine:
+    line_id = ModuleState.line_id
+    ModuleState.line_id += 1
+    return get_layout_line_for_text(text, line_id=line_id)
+
+
 class TestAffiliationAddressTeiTrainingDataGenerator:
     def test_should_include_layout_document_text_in_tei_output(self):
         training_data_generator = AffiliationAddressTeiTrainingDataGenerator()
@@ -127,8 +137,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_generate_tei_from_model_data(self):
         layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[
-            get_layout_line_for_text(TEXT_1, line_id=1),
-            get_layout_line_for_text(TEXT_2, line_id=2)
+            get_next_layout_line_for_text(TEXT_1),
+            get_next_layout_line_for_text(TEXT_2)
         ])])
         data_generator = get_data_generator()
         model_data_iterable = data_generator.iter_model_data_for_layout_document(
@@ -148,8 +158,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_generate_tei_from_model_data_using_model_labels(self):
         label_and_layout_line_list = [
-            ('<marker>', get_layout_line_for_text(TEXT_1, line_id=1)),
-            ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
+            ('<marker>', get_next_layout_line_for_text(TEXT_1)),
+            ('<institution>', get_next_layout_line_for_text(TEXT_2))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -171,7 +181,7 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [
-            ('<unknown>', get_layout_line_for_text(TEXT_1, line_id=1))
+            ('<unknown>', get_next_layout_line_for_text(TEXT_1))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -190,8 +200,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_not_join_separate_labels(self):
         label_and_layout_line_list = [
-            ('<institution>', get_layout_line_for_text(TEXT_1, line_id=1)),
-            ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
+            ('<institution>', get_next_layout_line_for_text(TEXT_1)),
+            ('<institution>', get_next_layout_line_for_text(TEXT_2))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -211,9 +221,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
     def test_should_generate_tei_from_multiple_model_data_lists_using_model_labels(self):
         label_and_layout_line_list_list = [
             [
-                ('<institution>', get_layout_line_for_text(TEXT_1, line_id=1))
+                ('<institution>', get_next_layout_line_for_text(TEXT_1))
             ], [
-                ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
+                ('<institution>', get_next_layout_line_for_text(TEXT_2))
             ]
         ]
         labeled_model_data_list_list = get_labeled_model_data_list_list(

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -76,6 +76,14 @@ def get_labeled_model_data_list_list(
     ]
 
 
+def get_layout_line_for_text(text: str, line_id: int) -> LayoutLine:
+    return LayoutLine.for_text(
+        text,
+        tail_whitespace='\n',
+        line_descriptor=LayoutLineDescriptor(line_id=line_id)
+    )
+
+
 class TestAffiliationAddressTeiTrainingDataGenerator:
     def test_should_include_layout_document_text_in_tei_output(self):
         training_data_generator = AffiliationAddressTeiTrainingDataGenerator()
@@ -119,16 +127,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_generate_tei_from_model_data(self):
         layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[
-            LayoutLine.for_text(
-                TEXT_1,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=1)
-            ),
-            LayoutLine.for_text(
-                TEXT_2,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=2)
-            )
+            get_layout_line_for_text(TEXT_1, line_id=1),
+            get_layout_line_for_text(TEXT_2, line_id=2)
         ])])
         data_generator = get_data_generator()
         model_data_iterable = data_generator.iter_model_data_for_layout_document(
@@ -148,16 +148,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_generate_tei_from_model_data_using_model_labels(self):
         label_and_layout_line_list = [
-            ('<marker>', LayoutLine.for_text(
-                TEXT_1,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=1)
-            )),
-            ('<institution>', LayoutLine.for_text(
-                TEXT_2,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=2)
-            ))
+            ('<marker>', get_layout_line_for_text(TEXT_1, line_id=1)),
+            ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -179,11 +171,7 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [
-            ('<unknown>', LayoutLine.for_text(
-                TEXT_1,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=1)
-            ))
+            ('<unknown>', get_layout_line_for_text(TEXT_1, line_id=1))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -202,16 +190,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
 
     def test_should_not_join_separate_labels(self):
         label_and_layout_line_list = [
-            ('<institution>', LayoutLine.for_text(
-                TEXT_1,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=1)
-            )),
-            ('<institution>', LayoutLine.for_text(
-                TEXT_2,
-                tail_whitespace='\n',
-                line_descriptor=LayoutLineDescriptor(line_id=2)
-            ))
+            ('<institution>', get_layout_line_for_text(TEXT_1, line_id=1)),
+            ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -231,17 +211,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
     def test_should_generate_tei_from_multiple_model_data_lists_using_model_labels(self):
         label_and_layout_line_list_list = [
             [
-                ('<institution>', LayoutLine.for_text(
-                    TEXT_1,
-                    tail_whitespace='\n',
-                    line_descriptor=LayoutLineDescriptor(line_id=1)
-                ))
+                ('<institution>', get_layout_line_for_text(TEXT_1, line_id=1))
             ], [
-                ('<institution>', LayoutLine.for_text(
-                    TEXT_2,
-                    tail_whitespace='\n',
-                    line_descriptor=LayoutLineDescriptor(line_id=2)
-                ))
+                ('<institution>', get_layout_line_for_text(TEXT_2, line_id=2))
             ]
         ]
         labeled_model_data_list_list = get_labeled_model_data_list_list(

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -179,6 +179,32 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         ) == [TEXT_2]
         assert get_text_content(aff_nodes[0]) == f'{TEXT_1}\n{TEXT_2}\n'
 
+    def test_should_generate_tei_for_most_labels(self):
+        label_and_layout_line_list = [
+            ('<marker>', get_next_layout_line_for_text('Marker 1')),
+            ('<institution>', get_next_layout_line_for_text('Institution 1')),
+            ('<department>', get_next_layout_line_for_text('Department 1'))
+        ]
+        labeled_model_data_list = get_labeled_model_data_list(
+            label_and_layout_line_list
+        )
+        training_data_generator = AffiliationAddressTeiTrainingDataGenerator()
+        xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
+            labeled_model_data_list
+        )
+        LOGGER.debug('xml: %r', etree.tostring(xml_root))
+        aff_nodes = xml_root.xpath(AFFILIATION_XPATH)
+        assert len(aff_nodes) == 1
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./marker')
+        ) == ['Marker 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./orgName[@type="institution"]')
+        ) == ['Institution 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./orgName[@type="department"]')
+        ) == ['Department 1']
+
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [
             ('<unknown>', get_next_layout_line_for_text(TEXT_1))

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -184,7 +184,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<marker>', get_next_layout_line_for_text('Marker 1')),
             ('<institution>', get_next_layout_line_for_text('Institution 1')),
             ('<department>', get_next_layout_line_for_text('Department 1')),
-            ('<laboratory>', get_next_layout_line_for_text('Laboratory 1'))
+            ('<laboratory>', get_next_layout_line_for_text('Laboratory 1')),
+            ('<addrLine>', get_next_layout_line_for_text('AddrLine 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -208,6 +209,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./orgName[@type="laboratory"]')
         ) == ['Laboratory 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/addrLine')
+        ) == ['AddrLine 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -186,7 +186,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<department>', get_next_layout_line_for_text('Department 1')),
             ('<laboratory>', get_next_layout_line_for_text('Laboratory 1')),
             ('<addrLine>', get_next_layout_line_for_text('AddrLine 1')),
-            ('<postCode>', get_next_layout_line_for_text('PostCode 1'))
+            ('<postCode>', get_next_layout_line_for_text('PostCode 1')),
+            ('<postBox>', get_next_layout_line_for_text('PostBox 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -216,6 +217,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/postCode')
         ) == ['PostCode 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/postBox')
+        ) == ['PostBox 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -188,7 +188,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<addrLine>', get_next_layout_line_for_text('AddrLine 1')),
             ('<postCode>', get_next_layout_line_for_text('PostCode 1')),
             ('<postBox>', get_next_layout_line_for_text('PostBox 1')),
-            ('<region>', get_next_layout_line_for_text('Region 1'))
+            ('<region>', get_next_layout_line_for_text('Region 1')),
+            ('<settlement>', get_next_layout_line_for_text('Settlement 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -224,6 +225,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/region')
         ) == ['Region 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/settlement')
+        ) == ['Settlement 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -187,7 +187,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<laboratory>', get_next_layout_line_for_text('Laboratory 1')),
             ('<addrLine>', get_next_layout_line_for_text('AddrLine 1')),
             ('<postCode>', get_next_layout_line_for_text('PostCode 1')),
-            ('<postBox>', get_next_layout_line_for_text('PostBox 1'))
+            ('<postBox>', get_next_layout_line_for_text('PostBox 1')),
+            ('<region>', get_next_layout_line_for_text('Region 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -220,6 +221,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/postBox')
         ) == ['PostBox 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/region')
+        ) == ['Region 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -189,7 +189,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<postCode>', get_next_layout_line_for_text('PostCode 1')),
             ('<postBox>', get_next_layout_line_for_text('PostBox 1')),
             ('<region>', get_next_layout_line_for_text('Region 1')),
-            ('<settlement>', get_next_layout_line_for_text('Settlement 1'))
+            ('<settlement>', get_next_layout_line_for_text('Settlement 1')),
+            ('<country>', get_next_layout_line_for_text('Country 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -228,6 +229,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/settlement')
         ) == ['Settlement 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/country')
+        ) == ['Country 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -185,7 +185,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<institution>', get_next_layout_line_for_text('Institution 1')),
             ('<department>', get_next_layout_line_for_text('Department 1')),
             ('<laboratory>', get_next_layout_line_for_text('Laboratory 1')),
-            ('<addrLine>', get_next_layout_line_for_text('AddrLine 1'))
+            ('<addrLine>', get_next_layout_line_for_text('AddrLine 1')),
+            ('<postCode>', get_next_layout_line_for_text('PostCode 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -212,6 +213,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/addrLine')
         ) == ['AddrLine 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address/postCode')
+        ) == ['PostCode 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -183,7 +183,8 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         label_and_layout_line_list = [
             ('<marker>', get_next_layout_line_for_text('Marker 1')),
             ('<institution>', get_next_layout_line_for_text('Institution 1')),
-            ('<department>', get_next_layout_line_for_text('Department 1'))
+            ('<department>', get_next_layout_line_for_text('Department 1')),
+            ('<laboratory>', get_next_layout_line_for_text('Laboratory 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list
@@ -204,6 +205,9 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./orgName[@type="department"]')
         ) == ['Department 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./orgName[@type="laboratory"]')
+        ) == ['Laboratory 1']
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -186,10 +186,15 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
             ('<department>', get_next_layout_line_for_text('Department 1')),
             ('<laboratory>', get_next_layout_line_for_text('Laboratory 1')),
             ('<addrLine>', get_next_layout_line_for_text('AddrLine 1')),
+            ('O', get_next_layout_line_for_text(',')),
             ('<postCode>', get_next_layout_line_for_text('PostCode 1')),
+            ('O', get_next_layout_line_for_text(',')),
             ('<postBox>', get_next_layout_line_for_text('PostBox 1')),
+            ('O', get_next_layout_line_for_text(',')),
             ('<region>', get_next_layout_line_for_text('Region 1')),
+            ('O', get_next_layout_line_for_text(',')),
             ('<settlement>', get_next_layout_line_for_text('Settlement 1')),
+            ('O', get_next_layout_line_for_text(',')),
             ('<country>', get_next_layout_line_for_text('Country 1'))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
@@ -232,6 +237,11 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert get_text_content_list(
             aff_nodes[0].xpath('./address/country')
         ) == ['Country 1']
+        assert get_text_content_list(
+            aff_nodes[0].xpath('./address')
+        ) == ['\n,\n'.join([
+            'AddrLine 1', 'PostCode 1', 'PostBox 1', 'Region 1', 'Settlement 1', 'Country 1'
+        ])]
 
     def test_should_map_unknown_label_to_note(self):
         label_and_layout_line_list = [

--- a/tests/models/affiliation_address/training_data_test.py
+++ b/tests/models/affiliation_address/training_data_test.py
@@ -108,6 +108,19 @@ class TestAffiliationAddressTeiTrainingDataGenerator:
         assert len(aff_nodes) == 1
         assert get_text_content(aff_nodes[0]).rstrip() == TEXT_1
 
+    def test_should_keep_original_whitespace(self):
+        training_data_generator = AffiliationAddressTeiTrainingDataGenerator()
+        text = 'Token1, Token2  ,Token3'
+        layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[
+            LayoutLine.for_text(text, tail_whitespace='\n')
+        ])])
+        xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
+            get_model_data_list_for_layout_document(layout_document)
+        )
+        aff_nodes = tei_xpath(xml_root, AFFILIATION_XPATH)
+        assert len(aff_nodes) == 1
+        assert get_text_content(aff_nodes[0]).rstrip() == text
+
     def test_should_add_line_feeds(self):
         training_data_generator = AffiliationAddressTeiTrainingDataGenerator()
         layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[

--- a/tests/models/header/training_data_test.py
+++ b/tests/models/header/training_data_test.py
@@ -74,6 +74,19 @@ class TestHeaderTeiTrainingDataGenerator:
         assert len(text_nodes) == 1
         assert get_text_content(text_nodes[0]).rstrip() == TEXT_1
 
+    def test_should_keep_original_whitespace(self):
+        training_data_generator = HeaderTeiTrainingDataGenerator()
+        text = 'Token1, Token2  ,Token3'
+        layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[
+            LayoutLine.for_text(text, tail_whitespace='\n')
+        ])])
+        xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
+            get_model_data_list_for_layout_document(layout_document)
+        )
+        text_nodes = xml_root.xpath('./text/front')
+        assert len(text_nodes) == 1
+        assert get_text_content(text_nodes[0]).rstrip() == text
+
     def test_should_add_line_feeds(self):
         training_data_generator = HeaderTeiTrainingDataGenerator()
         layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[

--- a/tests/models/segmentation/training_data_test.py
+++ b/tests/models/segmentation/training_data_test.py
@@ -75,6 +75,19 @@ class TestSegmentationTeiTrainingDataGenerator:
         assert len(text_nodes) == 1
         assert get_text_content(text_nodes[0]).rstrip() == TEXT_1
 
+    def test_should_keep_original_whitespace(self):
+        training_data_generator = SegmentationTeiTrainingDataGenerator()
+        text = 'Token1, Token2  ,Token3'
+        layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[
+            LayoutLine.for_text(text, tail_whitespace='\n')
+        ])])
+        xml_root = training_data_generator.get_training_tei_xml_for_model_data_iterable(
+            get_model_data_list_for_layout_document(layout_document)
+        )
+        text_nodes = xml_root.xpath('./text')
+        assert len(text_nodes) == 1
+        assert get_text_content(text_nodes[0]).rstrip() == text
+
     def test_should_add_line_feeds(self):
         training_data_generator = SegmentationTeiTrainingDataGenerator()
         layout_document = LayoutDocument.for_blocks([LayoutBlock(lines=[

--- a/tests/training/cli/generate_data_test.py
+++ b/tests/training/cli/generate_data_test.py
@@ -18,8 +18,6 @@ from sciencebeam_parser.training.cli.generate_data import (
     main
 )
 
-from tests.models.affiliation_address.training_data_test import AFFILIATION_XPATH
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -108,4 +106,3 @@ class TestMain:
         assert expected_aff_tei_path.exists()
         xml_root = etree.parse(str(expected_aff_tei_path)).getroot()
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
-        assert get_text_content_list(xml_root.xpath(AFFILIATION_XPATH))

--- a/tests/training/cli/generate_data_test.py
+++ b/tests/training/cli/generate_data_test.py
@@ -5,15 +5,20 @@ from pathlib import Path
 import pytest
 
 from lxml import etree
-from sciencebeam_parser.models.header.training_data import HeaderTeiTrainingDataGenerator
 
 from sciencebeam_parser.utils.xml import get_text_content_list
 from sciencebeam_parser.models.segmentation.training_data import (
     SegmentationTeiTrainingDataGenerator
 )
+from sciencebeam_parser.models.header.training_data import HeaderTeiTrainingDataGenerator
+from sciencebeam_parser.models.affiliation_address.training_data import (
+    AffiliationAddressTeiTrainingDataGenerator
+)
 from sciencebeam_parser.training.cli.generate_data import (
     main
 )
+
+from tests.models.affiliation_address.training_data_test import AFFILIATION_XPATH
 
 
 LOGGER = logging.getLogger(__name__)
@@ -96,3 +101,11 @@ class TestMain:
         xml_root = etree.parse(str(expected_header_tei_path)).getroot()
         LOGGER.debug('xml: %r', etree.tostring(xml_root))
         assert get_text_content_list(xml_root.xpath('text/front'))
+
+        expected_aff_tei_path = output_path.joinpath(
+            example_name + AffiliationAddressTeiTrainingDataGenerator.DEFAULT_TEI_FILENAME_SUFFIX
+        )
+        assert expected_aff_tei_path.exists()
+        xml_root = etree.parse(str(expected_aff_tei_path)).getroot()
+        LOGGER.debug('xml: %r', etree.tostring(xml_root))
+        assert get_text_content_list(xml_root.xpath(AFFILIATION_XPATH))


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/224

This adds support for the training data generation of the `affiliation-address` model.
It also refactor and re-uses some of the training data generation related code.