### PR TITLE
improve generate data tests

### DIFF
--- a/sciencebeam_parser/models/model.py
+++ b/sciencebeam_parser/models/model.py
@@ -2,7 +2,19 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union
+)
 
 from sciencebeam_trainer_delft.sequence_labelling.reader import load_data_crf_lines
 
@@ -27,6 +39,10 @@ from sciencebeam_parser.utils.lazy import LazyLoaded, Preloadable
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+T = TypeVar('T')
+U = TypeVar('U')
 
 
 @dataclass
@@ -369,37 +385,85 @@ class Model(ABC, Preloadable):
                     layout_token=token_model_data.layout_token
                 )
 
-    def iter_labeled_model_data_list_for_model_data_list_iterable(
+    def _iter_flat_label_model_data_lists_to(  # pylint: disable=too-many-locals
         self,
-        model_data_list_iterable: Iterable[Sequence[LayoutModelData]]
-    ) -> Iterable[Sequence[LabeledLayoutModelData]]:
+        model_data_list_iterable: Iterable[Sequence[LayoutModelData]],
+        item_factory: Callable[[str, LayoutModelData], T]
+    ) -> Iterable[Union[T, NewDocumentMarker]]:
         # Note: currently we do need a list
-        model_data_list_list = list(model_data_list_iterable)
-        if not model_data_list_list:
+        model_data_lists = list(model_data_list_iterable)
+        if not model_data_lists:
             return
         data_lines = list(iter_data_lines_for_model_data_iterables(
-            model_data_list_list
+            model_data_lists
         ))
         texts, features = load_data_crf_lines(data_lines)
         texts = texts.tolist()
         tag_result = self.predict_labels(
             texts=texts, features=features, output_format=None
         )
-        LOGGER.debug('texts: %r', texts)
-        LOGGER.debug('data_lines: %r', data_lines)
-        LOGGER.debug('tag_result: %r', tag_result)
-        LOGGER.debug('model_data_list_list[0]: %d', len(model_data_list_list[0]))
-        LOGGER.debug('tag_result[0]: %d', len(tag_result[0]))
-        assert len(tag_result) == len(model_data_list_list)
-        assert len(tag_result[0]) == len(model_data_list_list[0])
-        for model_data_list, doc_tag_result in zip(model_data_list_list, tag_result):
-            yield [
-                LabeledLayoutModelData.from_model_data(
-                    model_data,
-                    label=label
+        if not tag_result:
+            return
+        if len(tag_result) != len(model_data_lists):
+            raise AssertionError('tag result does not match number of docs: %d != %d' % (
+                len(tag_result), len(model_data_lists)
+            ))
+        for index, (doc_tag_result, model_data_list) in enumerate(
+            zip(tag_result, model_data_lists)
+        ):
+            if index > 0:
+                yield NEW_DOCUMENT_MARKER
+            if len(doc_tag_result) != len(model_data_list):
+                raise AssertionError('doc tag result does not match data: %d != %d' % (
+                    len(doc_tag_result), len(model_data_list)
+                ))
+            for token_tag_result, token_model_data in zip(doc_tag_result, model_data_list):
+                label_token_text, token_label = token_tag_result
+                if label_token_text != token_model_data.label_token_text:
+                    raise AssertionError(
+                        f'actual: {repr(label_token_text)}'
+                        f', expected: {repr(token_model_data.label_token_text)}'
+                    )
+                yield item_factory(
+                    token_label,
+                    token_model_data
                 )
-                for model_data, (_, label) in zip(model_data_list, doc_tag_result)
-            ]
+
+    def _iter_stacked_label_model_data_lists_to(
+        self,
+        model_data_list_iterable: Iterable[Sequence[LayoutModelData]],
+        item_factory: Callable[[str, LayoutModelData], T]
+    ) -> Iterable[Sequence[T]]:
+        # Note: currently we do need a list
+        model_data_lists = list(model_data_list_iterable)
+        if not model_data_lists:
+            return
+        doc_items: List[T] = []
+        result_doc_count = 0
+        for item in self._iter_flat_label_model_data_lists_to(
+            model_data_lists,
+            item_factory=item_factory
+        ):
+            if isinstance(item, NewDocumentMarker):
+                yield doc_items
+                doc_items = []
+                result_doc_count += 1
+                continue
+            doc_items.append(item)
+        if result_doc_count < len(model_data_lists):
+            yield doc_items
+
+    def iter_labeled_model_data_list_for_model_data_list_iterable(
+        self,
+        model_data_list_iterable: Iterable[Sequence[LayoutModelData]]
+    ) -> Iterable[Sequence[LabeledLayoutModelData]]:
+        return self._iter_stacked_label_model_data_lists_to(
+            model_data_list_iterable,
+            lambda label, model_data: LabeledLayoutModelData.from_model_data(
+                model_data,
+                label=label
+            )
+        )
 
     def get_label_layout_document_result(
         self,

--- a/sciencebeam_parser/models/model.py
+++ b/sciencebeam_parser/models/model.py
@@ -300,64 +300,6 @@ class Model(ABC, Preloadable):
     ) -> List[List[Tuple[str, str]]]:
         return self.model_impl.predict_labels(texts, features, output_format)
 
-    def iter_label_layout_documents(
-        self,
-        layout_documents: List[LayoutDocument],
-        app_features_context: AppFeaturesContext
-    ) -> Iterable[List[LayoutModelLabel]]:
-        doc_layout_model_labels: List[LayoutModelLabel] = []
-        result_doc_count = 0
-        for layout_model_label in self._iter_label_layout_documents(
-            layout_documents,
-            app_features_context=app_features_context
-        ):
-            if isinstance(layout_model_label, NewDocumentMarker):
-                yield doc_layout_model_labels
-                doc_layout_model_labels = []
-                result_doc_count += 1
-                continue
-            doc_layout_model_labels.append(layout_model_label)
-        if result_doc_count < len(layout_documents):
-            yield doc_layout_model_labels
-
-    def iter_label_layout_document(
-        self,
-        layout_document: LayoutDocument,
-        app_features_context: AppFeaturesContext
-    ) -> Iterable[LayoutModelLabel]:
-        for layout_model_label in self._iter_label_layout_documents(
-            [layout_document],
-            app_features_context=app_features_context
-        ):
-            assert isinstance(layout_model_label, LayoutModelLabel)
-            yield layout_model_label
-
-    def _iter_label_layout_documents(  # pylint: disable=too-many-locals
-        self,
-        layout_documents: Iterable[LayoutDocument],
-        app_features_context: AppFeaturesContext
-    ) -> Iterable[Union[LayoutModelLabel, NewDocumentMarker]]:
-        data_generator = self.get_data_generator(
-            document_features_context=DocumentFeaturesContext(
-                app_features_context=app_features_context
-            )
-        )
-        model_data_lists = [
-            list(data_generator.iter_model_data_for_layout_document(
-                layout_document
-            ))
-            for layout_document in layout_documents
-        ]
-        return self._iter_flat_label_model_data_lists_to(
-            model_data_lists,
-            lambda label, model_data: LayoutModelLabel(
-                label=label,
-                label_token_text=model_data.label_token_text,
-                layout_line=model_data.layout_line,
-                layout_token=model_data.layout_token
-            )
-        )
-
     def _iter_flat_label_model_data_lists_to(  # pylint: disable=too-many-locals
         self,
         model_data_list_iterable: Iterable[Sequence[LayoutModelData]],
@@ -425,6 +367,64 @@ class Model(ABC, Preloadable):
             doc_items.append(item)
         if result_doc_count < len(model_data_lists):
             yield doc_items
+
+    def iter_label_layout_documents(
+        self,
+        layout_documents: List[LayoutDocument],
+        app_features_context: AppFeaturesContext
+    ) -> Iterable[List[LayoutModelLabel]]:
+        doc_layout_model_labels: List[LayoutModelLabel] = []
+        result_doc_count = 0
+        for layout_model_label in self._iter_label_layout_documents(
+            layout_documents,
+            app_features_context=app_features_context
+        ):
+            if isinstance(layout_model_label, NewDocumentMarker):
+                yield doc_layout_model_labels
+                doc_layout_model_labels = []
+                result_doc_count += 1
+                continue
+            doc_layout_model_labels.append(layout_model_label)
+        if result_doc_count < len(layout_documents):
+            yield doc_layout_model_labels
+
+    def iter_label_layout_document(
+        self,
+        layout_document: LayoutDocument,
+        app_features_context: AppFeaturesContext
+    ) -> Iterable[LayoutModelLabel]:
+        for layout_model_label in self._iter_label_layout_documents(
+            [layout_document],
+            app_features_context=app_features_context
+        ):
+            assert isinstance(layout_model_label, LayoutModelLabel)
+            yield layout_model_label
+
+    def _iter_label_layout_documents(  # pylint: disable=too-many-locals
+        self,
+        layout_documents: Iterable[LayoutDocument],
+        app_features_context: AppFeaturesContext
+    ) -> Iterable[Union[LayoutModelLabel, NewDocumentMarker]]:
+        data_generator = self.get_data_generator(
+            document_features_context=DocumentFeaturesContext(
+                app_features_context=app_features_context
+            )
+        )
+        model_data_lists = [
+            list(data_generator.iter_model_data_for_layout_document(
+                layout_document
+            ))
+            for layout_document in layout_documents
+        ]
+        return self._iter_flat_label_model_data_lists_to(
+            model_data_lists,
+            lambda label, model_data: LayoutModelLabel(
+                label=label,
+                label_token_text=model_data.label_token_text,
+                layout_line=model_data.layout_line,
+                layout_token=model_data.layout_token
+            )
+        )
 
     def iter_labeled_model_data_list_for_model_data_list_iterable(
         self,

--- a/sciencebeam_parser/models/model.py
+++ b/sciencebeam_parser/models/model.py
@@ -348,42 +348,15 @@ class Model(ABC, Preloadable):
             ))
             for layout_document in layout_documents
         ]
-        data_lines = list(iter_data_lines_for_model_data_iterables(
-            model_data_lists
-        ))
-        texts, features = load_data_crf_lines(data_lines)
-        texts = texts.tolist()
-        tag_result = self.predict_labels(
-            texts=texts, features=features, output_format=None
+        return self._iter_flat_label_model_data_lists_to(
+            model_data_lists,
+            lambda label, model_data: LayoutModelLabel(
+                label=label,
+                label_token_text=model_data.label_token_text,
+                layout_line=model_data.layout_line,
+                layout_token=model_data.layout_token
+            )
         )
-        if not tag_result:
-            return
-        if len(tag_result) != len(model_data_lists):
-            raise AssertionError('tag result does not match number of docs: %d != %d' % (
-                len(tag_result), len(model_data_lists)
-            ))
-        for index, (doc_tag_result, model_data_list) in enumerate(
-            zip(tag_result, model_data_lists)
-        ):
-            if index > 0:
-                yield NEW_DOCUMENT_MARKER
-            if len(doc_tag_result) != len(model_data_list):
-                raise AssertionError('doc tag result does not match data: %d != %d' % (
-                    len(doc_tag_result), len(model_data_list)
-                ))
-            for token_tag_result, token_model_data in zip(doc_tag_result, model_data_list):
-                label_token_text, token_label = token_tag_result
-                if label_token_text != token_model_data.label_token_text:
-                    raise AssertionError(
-                        f'actual: {repr(label_token_text)}'
-                        f', expected: {repr(token_model_data.label_token_text)}'
-                    )
-                yield LayoutModelLabel(
-                    label=token_label,
-                    label_token_text=label_token_text,
-                    layout_line=token_model_data.layout_line,
-                    layout_token=token_model_data.layout_token
-                )
 
     def _iter_flat_label_model_data_lists_to(  # pylint: disable=too-many-locals
         self,

--- a/tests/processors/fulltext/model_mocks.py
+++ b/tests/processors/fulltext/model_mocks.py
@@ -1,0 +1,143 @@
+import logging
+from typing import Dict, Iterable, Mapping, Union
+from unittest.mock import MagicMock
+
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutDocument
+)
+from sciencebeam_parser.models.data import (
+    AppFeaturesContext,
+    DocumentFeaturesContext
+)
+from sciencebeam_parser.models.model import NEW_DOCUMENT_MARKER, NewDocumentMarker
+from sciencebeam_parser.models.model import LayoutModelLabel, Model
+from sciencebeam_parser.models.segmentation.model import SegmentationModel
+from sciencebeam_parser.models.header.model import HeaderModel
+from sciencebeam_parser.models.affiliation_address.model import AffiliationAddressModel
+from sciencebeam_parser.models.name.model import NameModel
+from sciencebeam_parser.models.fulltext.model import FullTextModel
+from sciencebeam_parser.models.figure.model import FigureModel
+from sciencebeam_parser.models.table.model import TableModel
+from sciencebeam_parser.models.reference_segmenter.model import ReferenceSegmenterModel
+from sciencebeam_parser.models.citation.model import CitationModel
+from sciencebeam_parser.processors.fulltext.models import (
+    FullTextModels
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+LayoutTokenId = int
+
+
+def get_label_by_layout_token_for_block(
+    layout_block: LayoutBlock,
+    label: str
+) -> Dict[LayoutTokenId, str]:
+    return {
+        id(layout_token): 'B-' + label if index == 0 else 'I-' + label
+        for index, layout_token in enumerate(layout_block.iter_all_tokens())
+    }
+
+
+class MockDelftModelWrapper:
+    def __init__(self, model_wrapper: Model):
+        self._model_wrapper = model_wrapper
+        self._label_by_layout_token: Dict[LayoutTokenId, str] = {}
+        self._default_label = 'O'
+        model_wrapper._lazy_model_impl._value = MagicMock(name='model_impl')
+        model_wrapper._iter_label_layout_documents = (  # type: ignore
+            self._iter_label_layout_documents
+        )
+
+    def update_label_by_layout_tokens(
+        self,
+        label_by_layout_token: Mapping[LayoutTokenId, str]
+    ):
+        self._label_by_layout_token.update(label_by_layout_token)
+
+    def update_label_by_layout_block(
+        self,
+        layout_block: LayoutBlock,
+        label: str
+    ):
+        self.update_label_by_layout_tokens(
+            get_label_by_layout_token_for_block(layout_block, label)
+        )
+
+    def _iter_label_layout_documents(
+        self,
+        layout_documents: Iterable[LayoutDocument],
+        app_features_context: AppFeaturesContext
+    ) -> Iterable[Union[LayoutModelLabel, NewDocumentMarker]]:
+        for index, layout_document in enumerate(layout_documents):
+            if index > 0:
+                yield NEW_DOCUMENT_MARKER
+            yield from self._iter_label_layout_document(
+                layout_document,
+                app_features_context=app_features_context
+            )
+
+    def _iter_label_layout_document(
+        self,
+        layout_document: LayoutDocument,
+        app_features_context: AppFeaturesContext
+    ) -> Iterable[LayoutModelLabel]:
+        data_generator = self._model_wrapper.get_data_generator(
+            document_features_context=DocumentFeaturesContext(
+                app_features_context=app_features_context
+            )
+        )
+        LOGGER.debug('_label_by_layout_token.keys: %s', self._label_by_layout_token.keys())
+        for model_data in data_generator.iter_model_data_for_layout_document(layout_document):
+            if model_data.layout_token:
+                label = self._label_by_layout_token.get(
+                    id(model_data.layout_token),
+                    self._default_label
+                )
+                LOGGER.debug('id(layout_token)=%r, label=%r', id(model_data.layout_token), label)
+            else:
+                assert model_data.layout_line
+                first_layout_token = model_data.layout_line.tokens[0]
+                label = self._label_by_layout_token.get(
+                    id(first_layout_token),
+                    self._default_label
+                )
+                LOGGER.debug('id(first_layout_token)=%r, label=%r', id(first_layout_token), label)
+            yield LayoutModelLabel(
+                label=label,
+                label_token_text='dummy',
+                layout_line=model_data.layout_line,
+                layout_token=model_data.layout_token
+            )
+
+
+class MockFullTextModels(FullTextModels):
+    def __init__(self):
+        model_impl_mock = MagicMock('model_impl')
+        super().__init__(
+            segmentation_model=SegmentationModel(model_impl_mock),
+            header_model=HeaderModel(model_impl_mock),
+            name_header_model=NameModel(model_impl_mock),
+            name_citation_model=NameModel(model_impl_mock),
+            affiliation_address_model=AffiliationAddressModel(model_impl_mock),
+            fulltext_model=FullTextModel(model_impl_mock),
+            figure_model=FigureModel(model_impl_mock),
+            table_model=TableModel(model_impl_mock),
+            reference_segmenter_model=ReferenceSegmenterModel(model_impl_mock),
+            citation_model=CitationModel(model_impl_mock)
+        )
+        self.segmentation_model_mock = MockDelftModelWrapper(self.segmentation_model)
+        self.header_model_mock = MockDelftModelWrapper(self.header_model)
+        self.name_header_model_mock = MockDelftModelWrapper(self.name_header_model)
+        self.name_citation_model_mock = MockDelftModelWrapper(self.name_citation_model)
+        self.affiliation_address_model_mock = MockDelftModelWrapper(
+            self.affiliation_address_model
+        )
+        self.fulltext_model_mock = MockDelftModelWrapper(self.fulltext_model)
+        self.figure_model_mock = MockDelftModelWrapper(self.figure_model)
+        self.table_model_mock = MockDelftModelWrapper(self.table_model)
+        self.reference_segmenter_model_mock = MockDelftModelWrapper(self.reference_segmenter_model)
+        self.citation_model_mock = MockDelftModelWrapper(self.citation_model)

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -1,7 +1,6 @@
 import logging
 import os
-from typing import Dict, Iterable, List, Mapping, Union
-from unittest.mock import MagicMock
+from typing import List
 
 import pytest
 
@@ -36,145 +35,15 @@ from sciencebeam_parser.document.semantic_document import (
     SemanticTitle,
     iter_by_semantic_type_recursively
 )
-from sciencebeam_parser.models.data import (
-    AppFeaturesContext,
-    DocumentFeaturesContext
-)
-from sciencebeam_parser.models.model import NEW_DOCUMENT_MARKER, NewDocumentMarker
-from sciencebeam_parser.models.model import LayoutModelLabel, Model
-from sciencebeam_parser.models.segmentation.model import SegmentationModel
-from sciencebeam_parser.models.header.model import HeaderModel
-from sciencebeam_parser.models.affiliation_address.model import AffiliationAddressModel
-from sciencebeam_parser.models.name.model import NameModel
-from sciencebeam_parser.models.fulltext.model import FullTextModel
-from sciencebeam_parser.models.figure.model import FigureModel
-from sciencebeam_parser.models.table.model import TableModel
-from sciencebeam_parser.models.reference_segmenter.model import ReferenceSegmenterModel
-from sciencebeam_parser.models.citation.model import CitationModel
-from sciencebeam_parser.processors.fulltext.models import (
-    FullTextModels
-)
+from sciencebeam_parser.models.model import LayoutModelLabel
 from sciencebeam_parser.processors.fulltext.processor import (
     FullTextProcessor,
     FullTextProcessorConfig
 )
+from tests.processors.fulltext.model_mocks import MockFullTextModels
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-LayoutTokenId = int
-
-
-def get_label_by_layout_token_for_block(
-    layout_block: LayoutBlock,
-    label: str
-) -> Dict[LayoutTokenId, str]:
-    return {
-        id(layout_token): 'B-' + label if index == 0 else 'I-' + label
-        for index, layout_token in enumerate(layout_block.iter_all_tokens())
-    }
-
-
-class MockDelftModelWrapper:
-    def __init__(self, model_wrapper: Model):
-        self._model_wrapper = model_wrapper
-        self._label_by_layout_token: Dict[LayoutTokenId, str] = {}
-        self._default_label = 'O'
-        model_wrapper._lazy_model_impl._value = MagicMock(name='model_impl')
-        model_wrapper._iter_label_layout_documents = (  # type: ignore
-            self._iter_label_layout_documents
-        )
-
-    def update_label_by_layout_tokens(
-        self,
-        label_by_layout_token: Mapping[LayoutTokenId, str]
-    ):
-        self._label_by_layout_token.update(label_by_layout_token)
-
-    def update_label_by_layout_block(
-        self,
-        layout_block: LayoutBlock,
-        label: str
-    ):
-        self.update_label_by_layout_tokens(
-            get_label_by_layout_token_for_block(layout_block, label)
-        )
-
-    def _iter_label_layout_documents(
-        self,
-        layout_documents: Iterable[LayoutDocument],
-        app_features_context: AppFeaturesContext
-    ) -> Iterable[Union[LayoutModelLabel, NewDocumentMarker]]:
-        for index, layout_document in enumerate(layout_documents):
-            if index > 0:
-                yield NEW_DOCUMENT_MARKER
-            yield from self._iter_label_layout_document(
-                layout_document,
-                app_features_context=app_features_context
-            )
-
-    def _iter_label_layout_document(
-        self,
-        layout_document: LayoutDocument,
-        app_features_context: AppFeaturesContext
-    ) -> Iterable[LayoutModelLabel]:
-        data_generator = self._model_wrapper.get_data_generator(
-            document_features_context=DocumentFeaturesContext(
-                app_features_context=app_features_context
-            )
-        )
-        LOGGER.debug('_label_by_layout_token.keys: %s', self._label_by_layout_token.keys())
-        for model_data in data_generator.iter_model_data_for_layout_document(layout_document):
-            if model_data.layout_token:
-                label = self._label_by_layout_token.get(
-                    id(model_data.layout_token),
-                    self._default_label
-                )
-                LOGGER.debug('id(layout_token)=%r, label=%r', id(model_data.layout_token), label)
-            else:
-                assert model_data.layout_line
-                first_layout_token = model_data.layout_line.tokens[0]
-                label = self._label_by_layout_token.get(
-                    id(first_layout_token),
-                    self._default_label
-                )
-                LOGGER.debug('id(first_layout_token)=%r, label=%r', id(first_layout_token), label)
-            yield LayoutModelLabel(
-                label=label,
-                label_token_text='dummy',
-                layout_line=model_data.layout_line,
-                layout_token=model_data.layout_token
-            )
-
-
-class MockFullTextModels(FullTextModels):
-    def __init__(self):
-        model_impl_mock = MagicMock('model_impl')
-        super().__init__(
-            segmentation_model=SegmentationModel(model_impl_mock),
-            header_model=HeaderModel(model_impl_mock),
-            name_header_model=NameModel(model_impl_mock),
-            name_citation_model=NameModel(model_impl_mock),
-            affiliation_address_model=AffiliationAddressModel(model_impl_mock),
-            fulltext_model=FullTextModel(model_impl_mock),
-            figure_model=FigureModel(model_impl_mock),
-            table_model=TableModel(model_impl_mock),
-            reference_segmenter_model=ReferenceSegmenterModel(model_impl_mock),
-            citation_model=CitationModel(model_impl_mock)
-        )
-        self.segmentation_model_mock = MockDelftModelWrapper(self.segmentation_model)
-        self.header_model_mock = MockDelftModelWrapper(self.header_model)
-        self.name_header_model_mock = MockDelftModelWrapper(self.name_header_model)
-        self.name_citation_model_mock = MockDelftModelWrapper(self.name_citation_model)
-        self.affiliation_address_model_mock = MockDelftModelWrapper(
-            self.affiliation_address_model
-        )
-        self.fulltext_model_mock = MockDelftModelWrapper(self.fulltext_model)
-        self.figure_model_mock = MockDelftModelWrapper(self.figure_model)
-        self.table_model_mock = MockDelftModelWrapper(self.table_model)
-        self.reference_segmenter_model_mock = MockDelftModelWrapper(self.reference_segmenter_model)
-        self.citation_model_mock = MockDelftModelWrapper(self.citation_model)
 
 
 @pytest.fixture(name='fulltext_models_mock')

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import List
 
 import pytest
 
@@ -35,7 +34,6 @@ from sciencebeam_parser.document.semantic_document import (
     SemanticTitle,
     iter_by_semantic_type_recursively
 )
-from sciencebeam_parser.models.model import LayoutModelLabel
 from sciencebeam_parser.processors.fulltext.processor import (
     FullTextProcessor,
     FullTextProcessorConfig
@@ -49,22 +47,6 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture(name='fulltext_models_mock')
 def _fulltext_models() -> MockFullTextModels:
     return MockFullTextModels()
-
-
-def _get_layout_model_labels_for_block(
-    layout_block: LayoutBlock,
-    label: str
-) -> List[LayoutModelLabel]:
-    return [
-        LayoutModelLabel(
-            label=label,
-            label_token_text=layout_token.text,
-            layout_line=layout_line,
-            layout_token=layout_token
-        )
-        for layout_line in layout_block.lines
-        for layout_token in layout_line.tokens
-    ]
 
 
 class TestFullTextProcessor:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+import logging
+import inspect
+from functools import wraps
+from typing import Callable, TypeVar, Union
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+T_WrappedCallable = TypeVar('T_WrappedCallable', bound=Callable)
+T_WrappedCallableOrType = Union[T_WrappedCallable, type]
+
+
+def wrap_class_methods(cls, wrapper):
+    for key, value in cls.__dict__.items():
+        if callable(value):
+            setattr(cls, key, wrapper(value))
+    return cls
+
+
+def log_on_exception(f: T_WrappedCallableOrType) -> T_WrappedCallableOrType:
+    """
+    Wraps function to log error on exception.
+    That is useful for tests that log a lot of things,
+    and pytest displaying the test failure at the top of the method.
+    (there doesn't seem to be an option to change that)
+    """
+    if inspect.isclass(f):
+        return wrap_class_methods(f, log_on_exception)
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            f(*args, **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            LOGGER.exception('failed due to %s', repr(e))
+            raise
+    return wrapper

--- a/tests/training/cli/generate_data_test.py
+++ b/tests/training/cli/generate_data_test.py
@@ -30,6 +30,7 @@ from sciencebeam_parser.training.cli.generate_data import (
 )
 
 from tests.processors.fulltext.model_mocks import MockFullTextModels
+from tests.test_utils import log_on_exception
 
 
 LOGGER = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ def normalize_whitespace_list(text_iterable: Iterable[str]) -> Sequence[str]:
     ]
 
 
+@log_on_exception
 class TestGenerateTrainingDataForLayoutDocument:
     def test_should_generate_data_using_mock_models(  # pylint: disable=too-many-locals
         self,
@@ -155,6 +157,7 @@ class TestGenerateTrainingDataForLayoutDocument:
 
 # Note: tests are currently using actual model and are therefore slow
 @pytest.mark.slow
+@log_on_exception
 class TestMain:
     def test_should_be_able_to_generate_segmentation_training_data(
         self,

--- a/tests/training/cli/generate_data_test.py
+++ b/tests/training/cli/generate_data_test.py
@@ -1,12 +1,22 @@
 import logging
 import os
+import re
 from pathlib import Path
+from typing import Iterable, Sequence
 
 import pytest
 
 from lxml import etree
 
+
 from sciencebeam_parser.utils.xml import get_text_content_list
+from sciencebeam_parser.document.layout_document import (
+    LayoutBlock,
+    LayoutDocument,
+    LayoutPage
+)
+from sciencebeam_parser.document.tei.common import tei_xpath
+from sciencebeam_parser.models.data import DEFAULT_DOCUMENT_FEATURES_CONTEXT
 from sciencebeam_parser.models.segmentation.training_data import (
     SegmentationTeiTrainingDataGenerator
 )
@@ -15,14 +25,132 @@ from sciencebeam_parser.models.affiliation_address.training_data import (
     AffiliationAddressTeiTrainingDataGenerator
 )
 from sciencebeam_parser.training.cli.generate_data import (
+    generate_training_data_for_layout_document,
     main
 )
+
+from tests.processors.fulltext.model_mocks import MockFullTextModels
 
 
 LOGGER = logging.getLogger(__name__)
 
 MINIMAL_EXAMPLE_PDF = 'test-data/minimal-example.pdf'
 MINIMAL_EXAMPLE_PDF_PATTERN = 'test-data/minimal-example*.pdf'
+
+
+SOURCE_FILENAME_1 = 'test1.pdf'
+
+
+@pytest.fixture(name='fulltext_models_mock')
+def _fulltext_models() -> MockFullTextModels:
+    return MockFullTextModels()
+
+
+def normalize_whitespace(text: str) -> str:
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+def normalize_whitespace_list(text_iterable: Iterable[str]) -> Sequence[str]:
+    return [
+        normalize_whitespace(text)
+        for text in text_iterable
+    ]
+
+
+class TestGenerateTrainingDataForLayoutDocument:
+    def test_should_generate_data_using_mock_models(  # pylint: disable=too-many-locals
+        self,
+        tmp_path: Path,
+        fulltext_models_mock: MockFullTextModels
+    ):
+        title_block = LayoutBlock.for_text('This is the title')
+        institution_block = LayoutBlock.for_text('Institution 1')
+        affiliation_block = LayoutBlock.merge_blocks([institution_block])
+        header_block = LayoutBlock.merge_blocks([title_block, affiliation_block])
+        body_block = LayoutBlock.for_text('This is the body')
+
+        segmentation_model_mock = fulltext_models_mock.segmentation_model_mock
+        header_model_mock = fulltext_models_mock.header_model_mock
+        affiliation_address_model_mock = fulltext_models_mock.affiliation_address_model_mock
+
+        segmentation_model_mock.update_label_by_layout_block(
+            header_block, '<header>'
+        )
+        segmentation_model_mock.update_label_by_layout_block(
+            body_block, '<body>'
+        )
+
+        header_model_mock.update_label_by_layout_block(
+            title_block, '<title>'
+        )
+        header_model_mock.update_label_by_layout_block(
+            affiliation_block, '<affiliation>'
+        )
+
+        affiliation_address_model_mock.update_label_by_layout_block(
+            institution_block, '<institution>'
+        )
+
+        layout_document = LayoutDocument(pages=[LayoutPage(blocks=[
+            header_block,
+            body_block
+        ])])
+
+        output_path = tmp_path / 'output'
+        output_path.mkdir()
+        generate_training_data_for_layout_document(
+            layout_document=layout_document,
+            output_path=str(output_path),
+            source_filename=SOURCE_FILENAME_1,
+            document_features_context=DEFAULT_DOCUMENT_FEATURES_CONTEXT,
+            fulltext_models=fulltext_models_mock,
+            use_model=True
+        )
+
+        example_name = os.path.splitext(os.path.basename(SOURCE_FILENAME_1))[0]
+        expected_segmentation_tei_path = output_path.joinpath(
+            example_name + SegmentationTeiTrainingDataGenerator.DEFAULT_TEI_FILENAME_SUFFIX
+        )
+        expected_segmentation_data_path = output_path.joinpath(
+            example_name + SegmentationTeiTrainingDataGenerator.DEFAULT_DATA_FILENAME_SUFFIX
+        )
+        assert expected_segmentation_tei_path.exists()
+        assert expected_segmentation_data_path.exists()
+        xml_root = etree.parse(str(expected_segmentation_tei_path)).getroot()
+        LOGGER.debug('xml: %r', etree.tostring(xml_root))
+        assert normalize_whitespace_list(
+            get_text_content_list(xml_root.xpath('text/front'))
+        ) == [
+            normalize_whitespace(header_block.text)
+        ]
+
+        expected_header_tei_path = output_path.joinpath(
+            example_name + HeaderTeiTrainingDataGenerator.DEFAULT_TEI_FILENAME_SUFFIX
+        )
+        expected_header_data_path = output_path.joinpath(
+            example_name + HeaderTeiTrainingDataGenerator.DEFAULT_DATA_FILENAME_SUFFIX
+        )
+        assert expected_header_tei_path.exists()
+        assert expected_header_data_path.exists()
+        xml_root = etree.parse(str(expected_header_tei_path)).getroot()
+        LOGGER.debug('xml: %r', etree.tostring(xml_root))
+        assert normalize_whitespace_list(get_text_content_list(
+            xml_root.xpath('text/front/docTitle/titlePart')
+        )) == [
+            normalize_whitespace(title_block.text)
+        ]
+
+        expected_aff_tei_path = output_path.joinpath(
+            example_name + AffiliationAddressTeiTrainingDataGenerator.DEFAULT_TEI_FILENAME_SUFFIX
+        )
+        assert expected_aff_tei_path.exists()
+        xml_root = etree.parse(str(expected_aff_tei_path)).getroot()
+        LOGGER.debug('xml: %r', etree.tostring(xml_root))
+        assert normalize_whitespace_list(get_text_content_list(
+            tei_xpath(xml_root, '//tei:affiliation/tei:orgName[@type="institution"]')
+        )) == [
+            normalize_whitespace(institution_block.text)
+        ]
 
 
 # Note: tests are currently using actual model and are therefore slow


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/224

This improves the test coverage of the generate training data tests, by mocking the sequential models.
At the same time the existing tests are no longer end-to-end.