### PR TITLE
added missing fulltext training data ref section

### DIFF
--- a/sciencebeam_parser/models/fulltext/training_data.py
+++ b/sciencebeam_parser/models/fulltext/training_data.py
@@ -22,6 +22,7 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<figure_marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['p', 'ref[@type="figure"]'],
     '<table_marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['p', 'ref[@type="table"]'],
     '<equation_marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['p', 'ref[@type="formula"]'],
+    '<section_marker>': ROOT_TRAINING_XML_ELEMENT_PATH + ['p', 'ref[@type="section"]'],
     '<figure>': ROOT_TRAINING_XML_ELEMENT_PATH + ['figure'],
     '<table>': ROOT_TRAINING_XML_ELEMENT_PATH + ['figure[@type="table"]'],
     '<equation>': ROOT_TRAINING_XML_ELEMENT_PATH + ['formula'],

--- a/tests/models/fulltext/training_data_test.py
+++ b/tests/models/fulltext/training_data_test.py
@@ -132,6 +132,7 @@ class TestFullTextTeiTrainingDataGenerator:
             ('<figure_marker>', get_next_layout_line_for_text('See Figure 1')),
             ('<table_marker>', get_next_layout_line_for_text('See Table 1')),
             ('<equation_marker>', get_next_layout_line_for_text('See Eq 1')),
+            ('<section_marker>', get_next_layout_line_for_text('See Section 1')),
             ('<figure>', get_next_layout_line_for_text('Figure 1')),
             ('<table>', get_next_layout_line_for_text('Table 1')),
             ('<equation>', get_next_layout_line_for_text('Eq 1')),
@@ -161,6 +162,9 @@ class TestFullTextTeiTrainingDataGenerator:
         assert get_text_content_list(
             xml_root.xpath('./text/p/ref[@type="formula"]')
         ) == ['See Eq 1']
+        assert get_text_content_list(
+            xml_root.xpath('./text/p/ref[@type="section"]')
+        ) == ['See Section 1']
         assert get_text_content_list(
             xml_root.xpath('./text/figure[not(@type="table")]')
         ) == ['Figure 1']


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/225
extension of #483

The `section_marker` wasn't mapped to `ref[@type="section"]`.

(And example can be found in `005587v1`)