### PR TITLE
extract tables as images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,12 @@ dev-start-no-debug-logging-auto-reload:
 	$(MAKE) dev-start
 
 
+dev-start-no-debug-logging-auto-reload-with-cv-and-ocr:
+	SCIENCEBEAM_PARSER__PROCESSORS__FULLTEXT__USE_CV_MODEL=true \
+	SCIENCEBEAM_PARSER__PROCESSORS__FULLTEXT__USE_OCR_MODEL=true \
+	$(MAKE) dev-start-no-debug-logging-auto-reload
+
+
 dev-end-to-end:
 	curl --fail --show-error \
 		--form "file=@$(EXAMPLE_PDF_DOCUMENT);filename=$(EXAMPLE_PDF_DOCUMENT)" \

--- a/sciencebeam_parser/cv_models/cv_model.py
+++ b/sciencebeam_parser/cv_models/cv_model.py
@@ -13,13 +13,21 @@ class ComputerVisionModelInstance(ABC):
     def get_bounding_box(self) -> BoundingBox:
         pass
 
+    @abstractmethod
+    def get_type_name(self) -> str:
+        pass
+
 
 @dataclass
 class SimpleComputerVisionModelInstance(ComputerVisionModelInstance):
     bounding_box: BoundingBox
+    type_name: str
 
     def get_bounding_box(self) -> BoundingBox:
         return self.bounding_box
+
+    def get_type_name(self) -> str:
+        return self.type_name
 
 
 class ComputerVisionModelResult(ABC):

--- a/sciencebeam_parser/cv_models/cv_model.py
+++ b/sciencebeam_parser/cv_models/cv_model.py
@@ -24,8 +24,17 @@ class SimpleComputerVisionModelInstance(ComputerVisionModelInstance):
 
 class ComputerVisionModelResult(ABC):
     @abstractmethod
-    def get_instances_by_type_name(self, type_name: str) -> Sequence[ComputerVisionModelInstance]:
+    def get_instances_by_type_names(
+        self,
+        type_names: Sequence[str]
+    ) -> Sequence[ComputerVisionModelInstance]:
         pass
+
+    def get_instances_by_type_name(
+        self,
+        type_name: str
+    ) -> Sequence[ComputerVisionModelInstance]:
+        return self.get_instances_by_type_names([type_name])
 
 
 class ComputerVisionModel(ABC, Preloadable):

--- a/sciencebeam_parser/cv_models/layout_parser_cv_model.py
+++ b/sciencebeam_parser/cv_models/layout_parser_cv_model.py
@@ -82,14 +82,17 @@ class LayoutParserComputerVisionModelResult(ComputerVisionModelResult):
         self.max_overlap_ratio = max_overlap_ratio
         LOGGER.debug('layout: %r', layout)
 
-    def get_instances_by_type_name(self, type_name: str) -> Sequence[ComputerVisionModelInstance]:
+    def get_instances_by_type_names(
+        self,
+        type_names: Sequence[str]
+    ) -> Sequence[ComputerVisionModelInstance]:
         instances = [
             LayoutParserComputerVisionModelInstance(
                 get_bounding_box_for_layout_parser_coordinates(block.coordinates)
             )
             for block in self.layout
             if (
-                block.type == type_name
+                block.type in type_names
                 and block.score >= self.score_threshold
             )
         ]

--- a/sciencebeam_parser/cv_models/layout_parser_cv_model.py
+++ b/sciencebeam_parser/cv_models/layout_parser_cv_model.py
@@ -11,7 +11,8 @@ from sciencebeam_parser.utils.bounding_box import BoundingBox
 from sciencebeam_parser.cv_models.cv_model import (
     ComputerVisionModel,
     ComputerVisionModelInstance,
-    ComputerVisionModelResult
+    ComputerVisionModelResult,
+    SimpleComputerVisionModelInstance
 )
 from sciencebeam_parser.utils.lazy import LazyLoaded
 
@@ -52,21 +53,6 @@ def is_bounding_box_overlapping_with_any_bounding_boxes(
     return False
 
 
-class LayoutParserComputerVisionModelInstance(ComputerVisionModelInstance):
-    def __init__(self, bounding_box: BoundingBox):
-        super().__init__()
-        self.bounding_box = bounding_box
-
-    def __repr__(self) -> str:
-        return '%s(bounding_box=%r)' % (
-            type(self).__name__,
-            self.bounding_box
-        )
-
-    def get_bounding_box(self) -> BoundingBox:
-        return self.bounding_box
-
-
 class LayoutParserComputerVisionModelResult(ComputerVisionModelResult):
     def __init__(
         self,
@@ -87,8 +73,9 @@ class LayoutParserComputerVisionModelResult(ComputerVisionModelResult):
         type_names: Sequence[str]
     ) -> Sequence[ComputerVisionModelInstance]:
         instances = [
-            LayoutParserComputerVisionModelInstance(
-                get_bounding_box_for_layout_parser_coordinates(block.coordinates)
+            SimpleComputerVisionModelInstance(
+                bounding_box=get_bounding_box_for_layout_parser_coordinates(block.coordinates),
+                type_name=block.type
             )
             for block in self.layout
             if (

--- a/sciencebeam_parser/processors/cv_graphic_provider.py
+++ b/sciencebeam_parser/processors/cv_graphic_provider.py
@@ -110,7 +110,7 @@ class ComputerVisionDocumentGraphicProvider(DocumentGraphicProvider):
         cv_start = monotonic()
         cv_result = self.computer_vision_model.predict_single(image)
         cv_end = monotonic()
-        figure_instances = cv_result.get_instances_by_type_name('Figure')
+        figure_instances = cv_result.get_instances_by_type_names(['Figure'])
         figure_coordinates_list = [
             instance.get_bounding_box() for instance in figure_instances
         ]

--- a/sciencebeam_parser/processors/cv_graphic_provider.py
+++ b/sciencebeam_parser/processors/cv_graphic_provider.py
@@ -110,7 +110,7 @@ class ComputerVisionDocumentGraphicProvider(DocumentGraphicProvider):
         cv_start = monotonic()
         cv_result = self.computer_vision_model.predict_single(image)
         cv_end = monotonic()
-        figure_instances = cv_result.get_instances_by_type_names(['Figure'])
+        figure_instances = cv_result.get_instances_by_type_names(['Figure', 'Table'])
         figure_coordinates_list = [
             instance.get_bounding_box() for instance in figure_instances
         ]

--- a/sciencebeam_parser/processors/fulltext/processor.py
+++ b/sciencebeam_parser/processors/fulltext/processor.py
@@ -342,7 +342,7 @@ class FullTextProcessor:
     ):
         unmatched_graphics_container = SemanticMixedNote(note_type='unmatched_graphics')
         candidate_semantic_content_list = list(
-            document.iter_by_type_recursively(SemanticFigure)
+            document.iter_by_types_recursively((SemanticFigure, SemanticTable,))
         )
         self._match_graphic_elements(
             semantic_graphic_list=list(

--- a/tests/processors/cv_graphic_provider_test.py
+++ b/tests/processors/cv_graphic_provider_test.py
@@ -137,7 +137,7 @@ class TestComputerVisionDocumentGraphicProvider:
         cv_result = computer_vision_model_mock.predict_single.return_value
         cv_bbox = BoundingBox(x=1, y=2, width=3, height=4)
         cv_result.get_instances_by_type_names.return_value = [
-            SimpleComputerVisionModelInstance(bounding_box=cv_bbox)
+            SimpleComputerVisionModelInstance(bounding_box=cv_bbox, type_name='Figure')
         ]
         expected_page_coordinates = LayoutPageCoordinates(
             x=10, y=20, width=30, height=40, page_number=10
@@ -197,7 +197,7 @@ class TestComputerVisionDocumentGraphicProvider:
         cv_result = computer_vision_model_mock.predict_single.return_value
         cv_bbox = BoundingBox(x=1, y=2, width=3, height=4)
         cv_result.get_instances_by_type_name.return_value = [
-            SimpleComputerVisionModelInstance(bounding_box=cv_bbox)
+            SimpleComputerVisionModelInstance(bounding_box=cv_bbox, type_name='Figure')
         ]
         graphic_provider = ComputerVisionDocumentGraphicProvider(
             computer_vision_model=computer_vision_model_mock,

--- a/tests/processors/cv_graphic_provider_test.py
+++ b/tests/processors/cv_graphic_provider_test.py
@@ -136,7 +136,7 @@ class TestComputerVisionDocumentGraphicProvider:
         ])
         cv_result = computer_vision_model_mock.predict_single.return_value
         cv_bbox = BoundingBox(x=1, y=2, width=3, height=4)
-        cv_result.get_instances_by_type_name.return_value = [
+        cv_result.get_instances_by_type_names.return_value = [
             SimpleComputerVisionModelInstance(bounding_box=cv_bbox)
         ]
         expected_page_coordinates = LayoutPageCoordinates(

--- a/tests/processors/fulltext/model_mocks.py
+++ b/tests/processors/fulltext/model_mocks.py
@@ -104,6 +104,7 @@ class MockDelftModelWrapper:
 class MockFullTextModels(FullTextModels):
     def __init__(self):
         model_impl_mock = MagicMock('model_impl')
+        self.cv_model_mock = MagicMock(name='cv_model')
         super().__init__(
             segmentation_model=SegmentationModel(model_impl_mock),
             header_model=HeaderModel(model_impl_mock),
@@ -114,7 +115,8 @@ class MockFullTextModels(FullTextModels):
             figure_model=FigureModel(model_impl_mock),
             table_model=TableModel(model_impl_mock),
             reference_segmenter_model=ReferenceSegmenterModel(model_impl_mock),
-            citation_model=CitationModel(model_impl_mock)
+            citation_model=CitationModel(model_impl_mock),
+            cv_model=self.cv_model_mock
         )
         self.segmentation_model_mock = MockDelftModelWrapper(self.segmentation_model)
         self.header_model_mock = MockDelftModelWrapper(self.header_model)

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -646,7 +646,7 @@ class TestFullTextProcessor:
         'segmentation_label',
         ['<body>', '<annex>']
     )
-    def test_should_extract_figure_label_caption_from_body(
+    def test_should_extract_figure_label_caption_and_graphic_from_body(
         self, fulltext_models_mock: MockFullTextModels,
         segmentation_label: str
     ):

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -646,7 +646,7 @@ class TestFullTextProcessor:
         'segmentation_label',
         ['<body>', '<annex>']
     )
-    def test_should_extract_figure_label_caption_and_graphic_from_body(
+    def test_should_extract_figure_label_caption_and_graphic(
         self, fulltext_models_mock: MockFullTextModels,
         segmentation_label: str
     ):

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -49,6 +49,7 @@ def _fulltext_models() -> MockFullTextModels:
     return MockFullTextModels()
 
 
+# pylint: disable=too-many-locals
 class TestFullTextProcessor:
     def test_should_not_fail_with_empty_document(
         self, fulltext_models_mock: MockFullTextModels
@@ -242,7 +243,7 @@ class TestFullTextProcessor:
         assert authors[0].given_name_text == given_name_block.text
         assert authors[0].surname_text == surname_block.text
 
-    def test_should_extract_affiliation_address_from_document(  # pylint: disable=too-many-locals
+    def test_should_extract_affiliation_address_from_document(
         self, fulltext_models_mock: MockFullTextModels
     ):
         marker_block = LayoutBlock.for_text('1')
@@ -298,7 +299,7 @@ class TestFullTextProcessor:
         assert affiliations[0].get_text_by_type(SemanticCountry) == country_block.text
         assert affiliations[0].content_id == 'aff0'
 
-    def test_should_not_merge_separate_raw_affiliations(  # pylint: disable=too-many-locals
+    def test_should_not_merge_separate_raw_affiliations(
         self, fulltext_models_mock: MockFullTextModels
     ):
         aff_suffix_texts = ['1', '2']
@@ -347,7 +348,7 @@ class TestFullTextProcessor:
             == ['aff0', 'aff1']
         )
 
-    def test_should_extract_raw_references_from_document(  # pylint: disable=too-many-locals
+    def test_should_extract_raw_references_from_document(
         self, fulltext_models_mock: MockFullTextModels
     ):
         label_block = LayoutBlock.for_text('1')
@@ -390,7 +391,7 @@ class TestFullTextProcessor:
         assert ref.get_text_by_type(SemanticRawReferenceText) == ref_text_block.text
         assert ref.content_id == 'b0'
 
-    def test_should_extract_references_fields_from_document(  # pylint: disable=too-many-locals
+    def test_should_extract_references_fields_from_document(
         self, fulltext_models_mock: MockFullTextModels
     ):
         other_body = LayoutBlock.for_text('the body')
@@ -461,7 +462,7 @@ class TestFullTextProcessor:
         assert len(ref_citations) == 1
         assert ref_citations[0].target_content_id == 'b0'
 
-    def test_should_extract_invalid_reference_from_document(  # pylint: disable=too-many-locals
+    def test_should_extract_invalid_reference_from_document(
         self, fulltext_models_mock: MockFullTextModels
     ):
         other_body = LayoutBlock.for_text('the body')
@@ -517,7 +518,7 @@ class TestFullTextProcessor:
         assert len(references) == 1
         assert references[0].get_text() == invalid_reference_block.text
 
-    def test_should_extract_author_names_from_references_fields(  # pylint: disable=too-many-locals
+    def test_should_extract_author_names_from_references_fields(
         self, fulltext_models_mock: MockFullTextModels
     ):
         given_name_block = LayoutBlock.for_text('Given name')
@@ -577,7 +578,7 @@ class TestFullTextProcessor:
         assert authors[0].given_name_text == given_name_block.text
         assert authors[0].surname_text == surname_block.text
 
-    def test_should_extract_editor_names_from_references_fields(  # pylint: disable=too-many-locals
+    def test_should_extract_editor_names_from_references_fields(
         self, fulltext_models_mock: MockFullTextModels
     ):
         given_name_block = LayoutBlock.for_text('Given name')
@@ -645,7 +646,7 @@ class TestFullTextProcessor:
         'segmentation_label',
         ['<body>', '<annex>']
     )
-    def test_should_extract_figure_label_caption_from_body(  # pylint: disable=too-many-locals
+    def test_should_extract_figure_label_caption_from_body(
         self, fulltext_models_mock: MockFullTextModels,
         segmentation_label: str
     ):
@@ -731,7 +732,7 @@ class TestFullTextProcessor:
         'segmentation_label',
         ['<body>', '<annex>']
     )
-    def test_should_extract_table_label_caption_from_body(  # pylint: disable=too-many-locals
+    def test_should_extract_table_label_caption_from_body(
         self, fulltext_models_mock: MockFullTextModels,
         segmentation_label: str
     ):

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -751,7 +751,7 @@ class TestFullTextProcessor:
         get_cv_document_graphic_provider_mock: MagicMock,
         segmentation_label: str
     ):
-        _coordinates = LayoutPageCoordinates(x=10, y=10, width=100, height=10)
+        _coordinates = LayoutPageCoordinates(x=10, y=10, width=100, height=10, page_number=10)
         graphic_local_file_path = '/path/to/graphic1.svg'
         graphic = LayoutGraphic(
             coordinates=_coordinates,
@@ -827,10 +827,13 @@ class TestFullTextProcessor:
         assert figure.get_text_by_type(SemanticCaption) == caption_block.text
         semantic_graphic_list = list(figure.iter_by_type(SemanticGraphic))
         assert semantic_graphic_list
-        # assert semantic_graphic_list[0].layout_graphic == graphic
+        assert semantic_graphic_list[0].layout_graphic == graphic
         assert semantic_graphic_list[0].relative_path == os.path.basename(
             graphic_local_file_path
         )
+        assert get_cv_document_graphic_provider_mock.call_args[1]['page_numbers'] == [
+            _coordinates.page_number
+        ]
 
     @pytest.mark.parametrize(
         'segmentation_label',
@@ -909,7 +912,7 @@ class TestFullTextProcessor:
         get_cv_document_graphic_provider_mock: MagicMock,
         segmentation_label: str
     ):
-        _coordinates = LayoutPageCoordinates(x=10, y=10, width=100, height=10)
+        _coordinates = LayoutPageCoordinates(x=10, y=10, width=100, height=10, page_number=10)
         graphic_local_file_path = '/path/to/graphic1.svg'
         graphic = LayoutGraphic(
             coordinates=_coordinates,
@@ -990,3 +993,6 @@ class TestFullTextProcessor:
         assert semantic_graphic_list[0].relative_path == os.path.basename(
             graphic_local_file_path
         )
+        assert get_cv_document_graphic_provider_mock.call_args[1]['page_numbers'] == [
+            _coordinates.page_number
+        ]

--- a/tests/processors/fulltext/processor_test.py
+++ b/tests/processors/fulltext/processor_test.py
@@ -732,7 +732,7 @@ class TestFullTextProcessor:
         'segmentation_label',
         ['<body>', '<annex>']
     )
-    def test_should_extract_table_label_caption_from_body(
+    def test_should_extract_table_label_caption(
         self, fulltext_models_mock: MockFullTextModels,
         segmentation_label: str
     ):


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/200

Like figures, extra tables as images. Table bounding boxes are detected using Layout Parser (if enabled).

The `/processFulltextAssetDocument` API endpoint can be used to extract the actual images (otherwise graphic elements with coordinates, but no path will be provided).

This will currently just look for tables on the same page as the table label and description.