### PR TITLE
Upgrade pdfalto to 0.6.0

### DIFF
--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -29,6 +29,7 @@ from sciencebeam_parser.processors.fulltext.models import FullTextModels
 from sciencebeam_parser.resources.xslt import TEI_TO_JATS_XSLT_FILE
 from sciencebeam_parser.transformers.doc_converter_wrapper import DocConverterWrapper
 from sciencebeam_parser.transformers.xslt import XsltTransformerWrapper
+from sciencebeam_parser.utils.download import download_with_zip_path_support
 from sciencebeam_parser.utils.lazy import LazyLoaded
 from sciencebeam_parser.utils.media_types import (
     MediaTypes
@@ -174,7 +175,10 @@ class ScienceBeamBaseParser:
             download_dir=get_download_dir(config)
         )
         self.pdfalto_wrapper = PdfAltoWrapper(
-            self.download_manager.download_if_url(config['pdfalto']['path'])
+            download_with_zip_path_support(
+                self.download_manager,
+                config['pdfalto']['path']
+            )
         )
         self.pdfalto_wrapper.ensure_executable()
         self.app_context = AppContext(

--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -40,7 +40,7 @@ logging:
 download_dir: '~/.cache/sciencebeam-parser/downloads'
 
 pdfalto:
-  path: https://github.com/kermitt2/pdfalto/files/6104204/pdfalto-4b4e983413278a07bb4cc4b2836de03adc8ca6dc-dockcross-linux-64.gz
+  path: https://github.com/kermitt2/pdfalto/releases/download/v0.6.0/pdfalto-bin-linux-64.zip!/pdfalto/linux/64/pdfalto
 wapiti:
   install_source: 'https://github.com/kermitt2/Wapiti/archive/a9c25d2bcccd60f1a54a7019689bd5229e866f00.tar.gz'
 xslt:

--- a/sciencebeam_parser/utils/download.py
+++ b/sciencebeam_parser/utils/download.py
@@ -1,12 +1,21 @@
+from dataclasses import dataclass
 import os
 import logging
-from typing import Sequence
+from shutil import copyfileobj
+from typing import Optional, Sequence
+import zipfile
 
 from sciencebeam_trainer_delft.utils.download_manager import DownloadManager
 from sciencebeam_trainer_delft.utils.io import is_external_location
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ZipUrl:
+    archive_url: str
+    inner_path: Optional[str]
 
 
 def download_if_url_from_alternatives(
@@ -37,3 +46,64 @@ def download_if_url_from_alternatives(
         except FileNotFoundError:
             LOGGER.debug('remote file not found: %r', file_url_or_path)
     raise FileNotFoundError('no file found for %r' % alternative_file_url_or_path_list)
+
+
+def parse_zip_url(value: str) -> ZipUrl:
+    if '!' not in value:
+        return ZipUrl(archive_url=value, inner_path=None)
+    archive_url, inner_path = value.split('!', 1)
+    return ZipUrl(archive_url=archive_url, inner_path=inner_path or None)
+
+
+def extract_file_from_zip_archive_to_file(
+    archive_file: str,
+    inner_path: str,
+    local_file: str
+) -> None:
+    tmp_file = local_file + '.part'
+    with zipfile.ZipFile(archive_file, 'r') as zf:
+        try:
+            member_name = inner_path.lstrip('/')
+            if member_name not in zf.namelist():
+                raise FileNotFoundError(
+                    f'inner path {member_name!r} not found in archive {archive_file!r}'
+                    + f' (available: {zf.namelist()!r})'
+                )
+
+            with zf.open(member_name, 'r') as source_fp, open(tmp_file, 'wb') as target_fp:
+                copyfileobj(source_fp, target_fp)
+            os.replace(tmp_file, local_file)
+        except Exception:
+            LOGGER.exception(
+                'error extracting %r from archive %r',
+                inner_path,
+                archive_file
+            )
+            if os.path.exists(tmp_file):
+                try:
+                    os.unlink(tmp_file)
+                except OSError:
+                    LOGGER.warning(
+                        'could not remove temporary file %r', tmp_file
+                    )
+            raise
+
+
+def download_with_zip_path_support(
+    download_manager: DownloadManager,
+    url: str
+) -> str:
+    zip_url = parse_zip_url(url)
+    if not zip_url.inner_path:
+        return download_manager.download_if_url(url)
+    local_file = download_manager.get_local_file(url)
+    if os.path.exists(local_file):
+        LOGGER.debug('local file for %r already exists: %r', url, local_file)
+        return local_file
+    archive_file = download_manager.download_if_url(zip_url.archive_url)
+    extract_file_from_zip_archive_to_file(
+        archive_file=archive_file,
+        inner_path=zip_url.inner_path,
+        local_file=local_file
+    )
+    return local_file

--- a/tests/external/pdfalto/wrapper_test.py
+++ b/tests/external/pdfalto/wrapper_test.py
@@ -8,6 +8,7 @@ from sciencebeam_parser.config.config import get_download_dir
 from sciencebeam_parser.external.pdfalto.wrapper import (
     PdfAltoWrapper
 )
+from sciencebeam_parser.utils.download import download_with_zip_path_support
 
 
 EXAMPLE_PDF_PATH = 'test-data/minimal-example.pdf'
@@ -19,7 +20,10 @@ def _pdfalto_wrapper(sciencebeam_parser_config: dict) -> PdfAltoWrapper:
         sciencebeam_parser_config
     ))
     pdfalto_wrapper = PdfAltoWrapper(
-        download_manager.download_if_url(sciencebeam_parser_config['pdfalto']['path'])
+        download_with_zip_path_support(
+            download_manager,
+            sciencebeam_parser_config['pdfalto']['path']
+        )
     )
     pdfalto_wrapper.ensure_executable()
     return pdfalto_wrapper


### PR DESCRIPTION
This avoids conversion errors on some arXiv PDFs

Had to add zip support for extracting binary from zip as that is how the binaries are currently released.