### PR TITLE
Fixed uvicorn logging not shown

### DIFF
--- a/sciencebeam_parser/resources/default_config/config.yml
+++ b/sciencebeam_parser/resources/default_config/config.yml
@@ -1,6 +1,7 @@
 logging:
   # Python logging config (passed to dictConfig)
   version: 1
+  disable_existing_loggers: false
   formatters:
     default:
       format: '[%(asctime)s] %(levelname)s in %(name)s:%(lineno)s: %(message)s'
@@ -32,6 +33,8 @@ logging:
     delft:
       level: INFO
     sciencebeam_trainer_delft:
+      level: INFO
+    uvicorn:
       level: INFO
 
 # The download directory for ScienceBeam Parser resources


### PR DESCRIPTION
The following uvicorn logging was no longer shown:

```shell
INFO:     Started server process [637092]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

This made it appear like the app hasn't started yet