### PR TITLE
Automatically resolve benchmark profile from profile: PR labels

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,10 +82,18 @@ jobs:
         run: |
           LABEL_PROFILE=$(echo "$PR_LABELS_JSON" | jq -r '.[] | select(startswith("profile:")) | sub("^profile:"; "")' | head -n1)
           PROFILE="${LABEL_PROFILE:-${DISPATCH_PROFILE:-grobid_crf}}"
+          if [ -n "$LABEL_PROFILE" ]; then
+            PROFILE_SOURCE="profile:$LABEL_PROFILE label"
+          elif [ -n "$DISPATCH_PROFILE" ]; then
+            PROFILE_SOURCE="workflow_dispatch input"
+          else
+            PROFILE_SOURCE="default"
+          fi
           if ! [[ "$PROFILE" =~ ^[A-Za-z0-9_]+$ ]]; then
-            echo "::error::Invalid profile '$PROFILE' (from label or input) - only letters, digits and underscores are allowed"
+            echo "::error::Invalid profile '$PROFILE' (from $PROFILE_SOURCE) - only letters, digits and underscores are allowed"
             exit 1
           fi
+          echo "::notice::Benchmark profile: $PROFILE (from $PROFILE_SOURCE)"
           echo "BENCHMARK_PROFILE=$PROFILE" >> "$GITHUB_ENV"
 
       - name: Set image tag

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,7 +80,7 @@ jobs:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
           DISPATCH_PROFILE: ${{ inputs.profile }}
         run: |
-          LABEL_PROFILE=$(echo "$PR_LABELS_JSON" | jq -r '.[] | select(startswith("profile:")) | sub("^profile:"; "")' | head -n1)
+          LABEL_PROFILE=$(echo "$PR_LABELS_JSON" | jq -r '.[]? | select(startswith("profile:")) | sub("^profile:"; "")' | head -n1)
           PROFILE="${LABEL_PROFILE:-${DISPATCH_PROFILE:-grobid_crf}}"
           if [ -n "$LABEL_PROFILE" ]; then
             PROFILE_SOURCE="profile:$LABEL_PROFILE label"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,13 +59,6 @@ jobs:
           github.ref == 'refs/heads/main' && 'medium' ||
           'smoke'
         }}
-      BENCHMARK_PROFILE: >-
-        ${{
-          contains(github.event.pull_request.labels.*.name, 'profile:grobid_crf') && 'grobid_crf' ||
-          contains(github.event.pull_request.labels.*.name, 'profile:biorxiv_elife') && 'biorxiv_elife' ||
-          inputs.profile ||
-          'grobid_crf'
-        }}
       # Automatic on main, where the numbers that get recorded are produced and where
       # the baseline other runs compare against is pushed: without it that baseline
       # has no PLOS predictions, so a labelled PR can compare PLOS against GROBID but
@@ -81,6 +74,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Resolve benchmark profile
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          DISPATCH_PROFILE: ${{ inputs.profile }}
+        run: |
+          LABEL_PROFILE=$(echo "$PR_LABELS_JSON" | jq -r '.[] | select(startswith("profile:")) | sub("^profile:"; "")' | head -n1)
+          PROFILE="${LABEL_PROFILE:-${DISPATCH_PROFILE:-grobid_crf}}"
+          if ! [[ "$PROFILE" =~ ^[A-Za-z0-9_]+$ ]]; then
+            echo "::error::Invalid profile '$PROFILE' (from label or input) - only letters, digits and underscores are allowed"
+            exit 1
+          fi
+          echo "BENCHMARK_PROFILE=$PROFILE" >> "$GITHUB_ENV"
 
       - name: Set image tag
         id: image_tag


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/113

The job-level BENCHMARK_PROFILE expression had to name every profile explicitly, so adding one meant editing this workflow as well. A step now extracts any profile:<name> label directly, validated against a safe character set, so new profiles no longer require a benchmark.yml edit.

This does change behaviour at the edges. Previously an unrecognised profile: label was ignored and the run silently used grobid_crf; now the label is taken at face value, so a typo reaches the container and the run fails at startup rather than quietly benchmarking the default. The validation covers the character set only, not whether the profile exists.