### PR TITLE
Drop the shipped-config assertion about grobid_custom_hybrid

### DIFF
--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -10,7 +10,6 @@ from sciencebeam_parser.config.config import (
     _deep_merge,
     _resolve_sequence_model_profile
 )
-from sciencebeam_parser.resources.default_config import DEFAULT_CONFIG_FILE
 
 
 MINIMAL_PROFILE_CONFIG = {
@@ -293,12 +292,3 @@ class TestAppConfig:
         config = AppConfig.load_yaml(str(config_path))
         config = config.apply_environment_variables()
         assert config.props['key1'] is False
-
-
-class TestDefaultConfigProfiles:
-    def _resolve_models(self, profile_name: str) -> dict:
-        config = AppConfig.load_yaml(DEFAULT_CONFIG_FILE)
-        return config.resolve_profile(profile_name)['models']
-
-    def test_grobid_custom_hybrid_inherits_every_grobid_crf_model(self):
-        assert self._resolve_models('grobid_custom_hybrid') == self._resolve_models('grobid_crf')


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/113

It asserted that grobid_custom_hybrid resolves to exactly what grobid_crf resolves to, which describes the config rather than any behaviour: the first custom model the profile takes on makes it fail, so a config change would have to arrive with a test change.

What it was there to show - that extends inherits the base and lets a profile state only its differences - is already covered by profile_b_extended in MINIMAL_PROFILE_CONFIG, and by the seven cases in
TestResolveSequenceModelProfile, none of which a model swap disturbs.