### PR TITLE
Temporary: open a PR for a pre-upgrade benchmark baseline

### DIFF
--- a/BENCHMARK_BASELINE.md
+++ b/BENCHMARK_BASELINE.md
@@ -1,0 +1,5 @@
+# Temporary: benchmark baseline branch
+
+Exists only to open a PR that triggers a benchmark run against `main` as it
+stands, before the trainer-delft 1.0 upgrade. Do not merge; delete the branch
+once the run has been recorded.


### PR DESCRIPTION
Carries no change to the package: a PR needs a diff against main to exist, and the benchmark runs on a labelled PR.