### PR TITLE
Lint benchmarks in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,19 +135,19 @@ COPY --from=python-dist-builder /opt/sciencebeam_parser/dist /dist
 # lint-flake8
 FROM dev AS lint-flake8
 
-RUN python -m flake8 sciencebeam_parser tests
+RUN python -m flake8 sciencebeam_parser tests benchmarks
 
 
 # lint-pylint
 FROM dev AS lint-pylint
 
-RUN python -m pylint sciencebeam_parser tests
+RUN python -m pylint sciencebeam_parser tests benchmarks
 
 
 # lint-mypy
 FROM dev AS lint-mypy
 
-RUN python -m mypy --ignore-missing-imports sciencebeam_parser tests
+RUN python -m mypy --ignore-missing-imports sciencebeam_parser tests benchmarks
 
 
 # pytest

--- a/benchmarks/tests/report_test.py
+++ b/benchmarks/tests/report_test.py
@@ -289,6 +289,8 @@ class TestRenderComparisonReport:  # pylint: disable=too-many-public-methods
 
 class TestUnequalDocsNote:
     def test_silent_when_every_run_covered_the_same_documents(self):
+        # pylint: disable=use-implicit-booleaness-not-comparison
+        # the empty list is the contract; `not ...` would also accept None
         assert _unequal_docs_note([("grobid", 10), ("local", 10)]) == []
 
     def test_calls_out_a_difference_with_the_counts(self):
@@ -351,5 +353,5 @@ class TestOverallRestrictedToCommonCorpora:
         assert "Overall (10 docs across 1 corpora)" in report
         assert "Excludes b, which not every run scored" in report
         # The unequal-columns warning belongs to b's own section, not the overall row.
-        overall = report.split("<details>")[0]
+        overall = report.split("<details>", maxsplit=1)[0]
         assert "Unequal document sets" not in overall


### PR DESCRIPTION
The Makefile's dev-flake8, dev-pylint and dev-mypy cover benchmarks, but the Docker lint stages did not, so that tree was checked only on a laptop and only by whoever remembered to run make dev-lint. It had been failing on main since #690 as a result.

The two findings it had accumulated go with it. The split gets maxsplit=1, which changes nothing. The empty-list comparison stays as it is, with a disable and a reason: `not ...` would accept None and the empty string equally, and the empty list is what the function contracts to return.

flake8 and mypy were already clean over benchmarks, so this only widens what they cover.