### PR TITLE
One identifier label for the citation model

### DIFF
--- a/benchmarks/analyze_field_regressions/_models.py
+++ b/benchmarks/analyze_field_regressions/_models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
+
 _REFERENCE_MODEL_LABELS: Dict[str, frozenset] = {
     'segmentation':        frozenset({'<references>'}),
     'reference-segmenter': frozenset({'<reference>'}),
@@ -13,7 +15,7 @@ _HEADER_MODEL_LABELS: Dict[str, frozenset] = {
 
 MODEL_RELEVANT_LABELS: Dict[str, Dict[str, frozenset]] = {
     'reference_doi':        {**_REFERENCE_MODEL_LABELS,
-                             'citation': frozenset({'<pubnum>', '<web>'})},
+                             'citation': frozenset({IDENTIFIER_LABEL, '<web>'})},
     'reference_title':      {**_REFERENCE_MODEL_LABELS, 'citation': frozenset({'<title>'})},
     'first_reference_text': _REFERENCE_MODEL_LABELS,
     'title':                {**_HEADER_MODEL_LABELS, 'header': frozenset({'<title>'})},

--- a/sciencebeam_parser/models/citation/extract.py
+++ b/sciencebeam_parser/models/citation/extract.py
@@ -25,6 +25,7 @@ from sciencebeam_parser.document.semantic_document import (
     T_SemanticContentFactory
 )
 from sciencebeam_parser.document.layout_document import LayoutBlock
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL, NOTE_CITATION_LABELS
 from sciencebeam_parser.models.extract import SimpleModelSemanticExtractor
 
 
@@ -181,7 +182,10 @@ def get_invalid_reference(ref: SemanticReference) -> SemanticInvalidReference:
 
 class CitationSemanticExtractor(SimpleModelSemanticExtractor):
     def __init__(self):
-        super().__init__(semantic_content_class_by_tag=SIMPLE_SEMANTIC_CONTENT_CLASS_BY_TAG)
+        super().__init__(
+            semantic_content_class_by_tag=SIMPLE_SEMANTIC_CONTENT_CLASS_BY_TAG,
+            expected_note_tags=NOTE_CITATION_LABELS
+        )
 
     def get_semantic_content_for_entity_name(  # pylint: disable=too-many-return-statements
         self,
@@ -192,7 +196,7 @@ class CitationSemanticExtractor(SimpleModelSemanticExtractor):
             return parse_page_range(layout_block)
         if name == '<web>':
             return parse_web(layout_block)
-        if name == '<pubnum>':
+        if name == IDENTIFIER_LABEL:
             return parse_pubnum(layout_block)
         if name == '<date>':
             return parse_date(layout_block)

--- a/sciencebeam_parser/models/citation/labels.py
+++ b/sciencebeam_parser/models/citation/labels.py
@@ -1,0 +1,44 @@
+from typing import AbstractSet, FrozenSet
+
+
+# The label set the citation model is trained and served against, matching GROBID's
+# citation corpus (grobid-trainer/resources/dataset/citation).
+#
+# Every identifier carries IDENTIFIER_LABEL, whatever kind it is; the kind is detected
+# from the text at extraction, so no label depends on a regex having matched.
+IDENTIFIER_LABEL = '<pubnum>'
+
+OTHER_LABEL = '<other>'
+
+CITATION_LABELS: FrozenSet[str] = frozenset({
+    '<author>',
+    '<booktitle>',
+    '<collaboration>',
+    '<date>',
+    '<editor>',
+    '<institution>',
+    '<issue>',
+    '<journal>',
+    '<location>',
+    '<note>',
+    OTHER_LABEL,
+    '<pages>',
+    '<publisher>',
+    '<series>',
+    '<tech>',
+    '<title>',
+    '<volume>',
+    '<web>',
+    IDENTIFIER_LABEL
+})
+
+# Labels with no semantic counterpart, which CitationSemanticExtractor keeps as notes.
+# Anything else in CITATION_LABELS has to map to semantic content.
+NOTE_CITATION_LABELS: AbstractSet[str] = frozenset({
+    '<booktitle>',
+    '<collaboration>',
+    '<institution>',
+    '<note>',
+    '<series>',
+    '<tech>'
+})

--- a/sciencebeam_parser/models/citation/labels.py
+++ b/sciencebeam_parser/models/citation/labels.py
@@ -2,10 +2,15 @@ from typing import AbstractSet, FrozenSet
 
 
 # The label set the citation model is trained and served against, matching GROBID's
-# citation corpus (grobid-trainer/resources/dataset/citation).
+# citation corpus.
 #
 # Every identifier carries IDENTIFIER_LABEL, whatever kind it is; the kind is detected
-# from the text at extraction, so no label depends on a regex having matched.
+# from the text at extraction, so no label depends on a regex having matched. This is
+# what GROBID does: TEICitationSaxParser maps both idno and pubnum to <pubnum>, and
+# CitationParser types the prediction afterwards via BiblioItem.checkIdentifier(). Its
+# training TEI carries the kind as an idno attribute, spelled type="arXiv" and
+# type="PMC" and also covering ISSN and ISBN, which is why the parser accepts any
+# idno type rather than the ones detection can produce here.
 IDENTIFIER_LABEL = '<pubnum>'
 
 OTHER_LABEL = '<other>'

--- a/sciencebeam_parser/models/citation/training_data.py
+++ b/sciencebeam_parser/models/citation/training_data.py
@@ -3,25 +3,19 @@ import re
 
 from lxml import etree
 
-from sciencebeam_parser.document.semantic_document import SemanticExternalIdentifierTypes
 from sciencebeam_parser.document.tei.common import TEI_NS_PREFIX, tei_xpath
 from sciencebeam_parser.models.training_data import (
     AbstractTeiTrainingDataGenerator,
-    AbstractTrainingTeiParser
+    AbstractTrainingTeiParser,
+    TeiTrainingElementPath
 )
 from sciencebeam_parser.models.citation.extract import (
     get_detected_external_identifier_type_for_text
 )
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
 from sciencebeam_parser.utils.xml import get_text_content
 
-# get_post_processed_xml_root tags <idno> elements with any detected identifier type
-# (not just DOI); all but DOI should still resolve back to the <pubnum> label
-_PUBNUM_EXTERNAL_IDENTIFIER_TYPES = (
-    SemanticExternalIdentifierTypes.ARXIV,
-    SemanticExternalIdentifierTypes.PII,
-    SemanticExternalIdentifierTypes.PMCID,
-    SemanticExternalIdentifierTypes.PMID,
-)
+_IDNO_TAG = TEI_NS_PREFIX + 'idno'
 
 # Matches "388 - 412", "281-282", "1199 -1207" etc.
 _PAGE_RANGE_RE = re.compile(r'^(\S+)\s*[-–]\s*(\S+)$')
@@ -52,10 +46,13 @@ TRAINING_XML_ELEMENT_PATH_BY_LABEL = {
     '<location>': ROOT_TRAINING_XML_ELEMENT_PATH + ['pubPlace'],
     '<tech>': ROOT_TRAINING_XML_ELEMENT_PATH + ['note[@type="report"]'],
     '<web>': ROOT_TRAINING_XML_ELEMENT_PATH + ['ptr[@type="web"]'],
-    '<idno>': ROOT_TRAINING_XML_ELEMENT_PATH + ['idno[@type="DOI"]'],
-    '<pubnum>': ROOT_TRAINING_XML_ELEMENT_PATH + ['idno'],
+    IDENTIFIER_LABEL: ROOT_TRAINING_XML_ELEMENT_PATH + ['idno'],
     '<note>': ROOT_TRAINING_XML_ELEMENT_PATH + ['note']
 }
+
+
+def _is_idno_path_step(path_step: str) -> bool:
+    return path_step == _IDNO_TAG or path_step.startswith(_IDNO_TAG + '[')
 
 
 class CitationTeiTrainingDataGenerator(AbstractTeiTrainingDataGenerator):
@@ -101,7 +98,13 @@ class CitationTrainingTeiParser(AbstractTrainingTeiParser):
             ),
             use_tei_namespace=True
         )
-        for external_identifier_type in _PUBNUM_EXTERNAL_IDENTIFIER_TYPES:
-            self.label_by_relative_element_path_map[
-                ('{}idno[@type="{}"]'.format(TEI_NS_PREFIX, external_identifier_type),)
-            ] = '<pubnum>'
+
+    def get_label_for_element_path(
+        self,
+        tei_training_element_path: TeiTrainingElementPath,
+        text: str
+    ) -> str:
+        element_path = tei_training_element_path.get_path()
+        if element_path and _is_idno_path_step(element_path[-1]):
+            return IDENTIFIER_LABEL
+        return super().get_label_for_element_path(tei_training_element_path, text=text)

--- a/sciencebeam_parser/models/extract.py
+++ b/sciencebeam_parser/models/extract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import logging
 import re
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import AbstractSet, Iterable, Mapping, Optional, Set, Tuple
 
 from sciencebeam_parser.document.semantic_document import (
     SemanticContentWrapper,
@@ -9,6 +9,7 @@ from sciencebeam_parser.document.semantic_document import (
     T_SemanticContentFactory
 )
 from sciencebeam_parser.document.layout_document import EMPTY_BLOCK, LayoutBlock, LayoutTokensText
+from sciencebeam_parser.utils.labels import OTHER_LABELS
 
 
 LOGGER = logging.getLogger(__name__)
@@ -57,10 +58,28 @@ class SimpleModelSemanticExtractor(ModelSemanticExtractor):
         self,
         semantic_content_class_by_tag: Optional[
             Mapping[str, T_SemanticContentFactory]
-        ] = None
+        ] = None,
+        *,
+        expected_note_tags: Optional[AbstractSet[str]] = None
     ):
         super().__init__()
         self.semantic_content_class_by_tag = semantic_content_class_by_tag or {}
+        self.expected_note_tags = expected_note_tags
+        self._reported_unexpected_note_tags: Set[str] = set()
+
+    def _report_unexpected_note_tag(self, name: str) -> None:
+        if self.expected_note_tags is None:
+            return
+        if name in self.expected_note_tags or name in OTHER_LABELS:
+            return
+        if name in self._reported_unexpected_note_tags:
+            return
+        self._reported_unexpected_note_tags.add(name)
+        LOGGER.warning(
+            'no semantic content for label %r, keeping it as a note'
+            ' (it will not appear in any extracted field)',
+            name
+        )
 
     def get_semantic_content_for_entity_name(
         self,
@@ -70,6 +89,7 @@ class SimpleModelSemanticExtractor(ModelSemanticExtractor):
         semantic_content_class = self.semantic_content_class_by_tag.get(name)
         if semantic_content_class:
             return semantic_content_class(layout_block=layout_block)
+        self._report_unexpected_note_tag(name)
         return SemanticNote(
             layout_block=layout_block,
             note_type=name

--- a/sciencebeam_parser/models/training_data.py
+++ b/sciencebeam_parser/models/training_data.py
@@ -7,7 +7,7 @@ from lxml import etree
 from lxml.builder import ElementMaker
 
 from sciencebeam_parser.utils.xml_writer import XmlTreeWriter
-from sciencebeam_parser.utils.labels import get_split_prefix_label
+from sciencebeam_parser.utils.labels import OTHER_LABELS, get_split_prefix_label
 from sciencebeam_parser.utils.tokenizer import get_tokenized_tokens
 from sciencebeam_parser.document.tei.common import TEI_E, TEI_NS_PREFIX, tei_xpath
 from sciencebeam_parser.document.layout_document import (
@@ -28,9 +28,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 NO_NS_TEI_E = ElementMaker()
-
-
-OTHER_LABELS = {'<other>', 'O'}
 
 
 class ExtractInstruction:
@@ -568,7 +565,7 @@ class AbstractTrainingTeiParser(TrainingTeiParser):
         self.root_training_xml_xpath = './' + '/'.join(root_training_xml_element_path)
         self.line_as_token = line_as_token
 
-    def _get_label_for_element_path(
+    def get_label_for_element_path(
         self,
         tei_training_element_path: TeiTrainingElementPath,
         text: str
@@ -605,7 +602,7 @@ class AbstractTrainingTeiParser(TrainingTeiParser):
                         continue
                     token_count = 0
                     if text.path.element_list:
-                        label = self._get_label_for_element_path(text.path, text=text.text)
+                        label = self.get_label_for_element_path(text.path, text=text.text)
                         if prev_label != label:
                             prefix = 'B-' if text.is_start else 'I-'
                     else:

--- a/sciencebeam_parser/training/cli/generate_data.py
+++ b/sciencebeam_parser/training/cli/generate_data.py
@@ -41,6 +41,7 @@ from sciencebeam_parser.models.model import (
     iter_data_lines_for_model_data_iterables,
     iter_labeled_layout_token_for_layout_model_label
 )
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
 from sciencebeam_parser.models.training_data import TeiTrainingDataGenerator
 from sciencebeam_parser.processors.fulltext.models import FullTextModels
 from sciencebeam_parser.resources.default_config import DEFAULT_CONFIG_FILE
@@ -1166,16 +1167,33 @@ class CitationModelTrainingDataGenerator(AbstractDocumentModelTrainingDataGenera
         return document_context.fulltext_models.citation_model
 
     def get_jats_label_fn(self) -> Optional[JatsLabelFn]:
+        previous_identifier: Optional[Tuple[int, Optional[str]]] = None
+
         def fn(
             annotated: JatsAnnotatedLayoutDocument,
             _seg_labels: Dict[int, str],
             md: LayoutModelData,
         ) -> Optional[str]:
+            nonlocal previous_identifier
             token = md.layout_token
             if not token:
                 return None
             sub_field = annotated.get_token_sub_field(token)
-            return CITATION_LABEL_BY_SUB_FIELD.get(sub_field or '') if sub_field else None
+            label = CITATION_LABEL_BY_SUB_FIELD.get(sub_field or '') if sub_field else None
+            if label != IDENTIFIER_LABEL:
+                previous_identifier = None
+                return label
+            # Identifiers of different kinds share one label, so without a B- prefix a DOI
+            # directly followed by a PMID would be written as a single <idno>, and typed as
+            # one identifier whose value carries both.
+            identifier = (annotated.get_token_instance(token), sub_field)
+            is_new_identifier = (
+                previous_identifier is not None
+                and previous_identifier[0] == identifier[0]
+                and previous_identifier[1] != identifier[1]
+            )
+            previous_identifier = identifier
+            return 'B-' + label if is_new_identifier else label
         return fn
 
     def iter_model_layout_documents(

--- a/sciencebeam_parser/training/jats/field_vocab.py
+++ b/sciencebeam_parser/training/jats/field_vocab.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
+
 
 class JatsFieldNames:
     TITLE = 'title'
@@ -116,9 +118,9 @@ CITATION_LABEL_BY_SUB_FIELD: Dict[str, str] = {
     JatsSubFieldNames.REFERENCE_ISSUE:           '<issue>',
     JatsSubFieldNames.REFERENCE_FPAGE:           '<pages>',
     JatsSubFieldNames.REFERENCE_LPAGE:           '<pages>',
-    JatsSubFieldNames.REFERENCE_DOI:             '<idno>',
-    JatsSubFieldNames.REFERENCE_PMID:            '<pubnum>',
-    JatsSubFieldNames.REFERENCE_PMCID:           '<pubnum>',
+    JatsSubFieldNames.REFERENCE_DOI:             IDENTIFIER_LABEL,
+    JatsSubFieldNames.REFERENCE_PMID:            IDENTIFIER_LABEL,
+    JatsSubFieldNames.REFERENCE_PMCID:           IDENTIFIER_LABEL,
     JatsSubFieldNames.REFERENCE_WEB:             '<web>',
     JatsSubFieldNames.REFERENCE_LABEL:           '<note>',
     JatsSubFieldNames.REFERENCE_PUBLISHER_NAME:  '<publisher>',

--- a/sciencebeam_parser/utils/labels.py
+++ b/sciencebeam_parser/utils/labels.py
@@ -1,4 +1,7 @@
-from typing import Tuple
+from typing import FrozenSet, Tuple
+
+
+OTHER_LABELS: FrozenSet[str] = frozenset({'<other>', 'O'})
 
 
 def strip_tag_prefix(tag: str) -> str:

--- a/tests/models/citation/labels_test.py
+++ b/tests/models/citation/labels_test.py
@@ -1,0 +1,59 @@
+import logging
+
+import pytest
+
+from sciencebeam_parser.document.layout_document import LayoutBlock
+from sciencebeam_parser.document.semantic_document import SemanticNote
+from sciencebeam_parser.models.citation.extract import CitationSemanticExtractor
+from sciencebeam_parser.models.citation.labels import (
+    CITATION_LABELS,
+    IDENTIFIER_LABEL,
+    NOTE_CITATION_LABELS,
+    OTHER_LABEL
+)
+from sciencebeam_parser.models.citation.training_data import (
+    TRAINING_XML_ELEMENT_PATH_BY_LABEL
+)
+from sciencebeam_parser.training.jats.field_vocab import CITATION_LABEL_BY_SUB_FIELD
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+TEXT_1 = 'text 1'
+
+
+class TestCitationLabels:
+    def test_should_declare_note_labels_within_the_label_set(self):
+        assert NOTE_CITATION_LABELS <= CITATION_LABELS
+
+    def test_should_declare_identifier_label_within_the_label_set(self):
+        assert IDENTIFIER_LABEL in CITATION_LABELS
+
+    def test_should_generate_training_tei_for_every_label_except_other(self):
+        assert set(TRAINING_XML_ELEMENT_PATH_BY_LABEL.keys()) == CITATION_LABELS - {OTHER_LABEL}
+
+    def test_should_only_use_known_labels_for_jats_sub_fields(self):
+        assert set(CITATION_LABEL_BY_SUB_FIELD.values()) <= CITATION_LABELS
+
+    def test_should_use_the_identifier_label_for_every_jats_identifier_sub_field(self):
+        identifier_labels = {
+            label
+            for sub_field, label in CITATION_LABEL_BY_SUB_FIELD.items()
+            if sub_field.endswith(('-doi', '-pmid', '-pmcid'))
+        }
+        assert identifier_labels == {IDENTIFIER_LABEL}
+
+    @pytest.mark.parametrize("label", sorted(CITATION_LABELS - {OTHER_LABEL}))
+    def test_should_extract_semantic_content_for_every_label_that_is_not_a_declared_note(
+        self,
+        label: str
+    ):
+        semantic_content = CitationSemanticExtractor().get_semantic_content_for_entity_name(
+            label, layout_block=LayoutBlock.for_text(TEXT_1)
+        )
+        LOGGER.debug('semantic_content: %r', semantic_content)
+        if label in NOTE_CITATION_LABELS:
+            assert isinstance(semantic_content, SemanticNote)
+        else:
+            assert not isinstance(semantic_content, SemanticNote)

--- a/tests/models/citation/training_data_test.py
+++ b/tests/models/citation/training_data_test.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional, Sequence, Tuple
 
 import pytest
 from lxml import etree
@@ -9,7 +9,11 @@ from sciencebeam_parser.document.layout_document import (
     LayoutDocument,
     LayoutLine
 )
-from sciencebeam_parser.document.semantic_document import SemanticExternalIdentifierTypes
+from sciencebeam_parser.document.semantic_document import (
+    SemanticExternalIdentifier,
+    SemanticExternalIdentifierTypes,
+    SemanticReference
+)
 from sciencebeam_parser.document.tei.common import (
     TEI_E,
     get_tei_xpath_text_content_list,
@@ -20,7 +24,12 @@ from sciencebeam_parser.models.data import (
     DEFAULT_DOCUMENT_FEATURES_CONTEXT,
     LayoutModelData
 )
+from sciencebeam_parser.models.model import (
+    iter_entity_layout_blocks_for_labeled_layout_tokens
+)
 from sciencebeam_parser.models.citation.data import CitationDataGenerator
+from sciencebeam_parser.models.citation.extract import CitationSemanticExtractor
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
 from sciencebeam_parser.models.citation.training_data import (
     ROOT_TRAINING_XML_ELEMENT_PATH,
     TRAINING_XML_ELEMENT_PATH_BY_LABEL,
@@ -76,6 +85,32 @@ def get_training_tei_xml_for_model_data_iterable(
     )
     LOGGER.debug('xml: %r', etree.tostring(xml_root))
     return xml_root
+
+
+def get_semantic_references_for_training_tei_xml(
+    xml_root: etree.ElementBase
+) -> Sequence[SemanticReference]:
+    extractor = CitationSemanticExtractor()
+    labeled_layout_tokens_list = (
+        get_training_tei_parser().parse_training_tei_to_labeled_layout_tokens_list(xml_root)
+    )
+    return [
+        semantic_content
+        for labeled_layout_tokens in labeled_layout_tokens_list
+        for semantic_content in extractor.iter_semantic_content_for_entity_blocks(
+            iter_entity_layout_blocks_for_labeled_layout_tokens(labeled_layout_tokens)
+        )
+        if isinstance(semantic_content, SemanticReference)
+    ]
+
+
+def get_external_identifier_types_and_values(
+    semantic_reference: SemanticReference
+) -> Sequence[Tuple[Optional[str], Optional[str]]]:
+    return [
+        (external_identifier.external_identifier_type, external_identifier.value)
+        for external_identifier in semantic_reference.iter_by_type(SemanticExternalIdentifier)
+    ]
 
 
 def get_training_tei_xml_for_layout_document(
@@ -450,17 +485,17 @@ class TestCitationTrainingTeiParser:
         "external_identifier_type",
         [
             SemanticExternalIdentifierTypes.ARXIV,
+            SemanticExternalIdentifierTypes.DOI,
             SemanticExternalIdentifierTypes.PII,
             SemanticExternalIdentifierTypes.PMCID,
-            SemanticExternalIdentifierTypes.PMID
+            SemanticExternalIdentifierTypes.PMID,
+            'other'
         ]
     )
-    def test_should_parse_non_doi_idno_type_as_pubnum(
+    def test_should_parse_any_idno_type_as_identifier_label(
         self,
         external_identifier_type: str
     ):
-        # get_post_processed_xml_root tags <pubnum>-derived <idno> elements with the
-        # detected identifier type (e.g. PMCID); parsing must still recover <pubnum>
         tei_root = _get_training_tei_with_references([
             TEI_E('bibl', *[
                 TEI_E('idno', {'type': external_identifier_type}, TOKEN_1, TEI_E('lb')),
@@ -471,12 +506,26 @@ class TestCitationTrainingTeiParser:
             tei_root
         )
         assert tag_result == [[
-            (TOKEN_1, 'B-<pubnum>')
+            (TOKEN_1, f'B-{IDENTIFIER_LABEL}')
         ]]
 
-    def test_should_round_trip_pubnum_with_detected_external_identifier_type(self):
+    @pytest.mark.parametrize(
+        "text,expected_type,expected_value",
+        [
+            ('10.1234/test', SemanticExternalIdentifierTypes.DOI, '10.1234/test'),
+            ('arXiv: 0706.0001', SemanticExternalIdentifierTypes.ARXIV, '0706.0001'),
+            ('PMID: 1234567', SemanticExternalIdentifierTypes.PMID, '1234567'),
+            ('PMC1234567', SemanticExternalIdentifierTypes.PMCID, 'PMC1234567')
+        ]
+    )
+    def test_should_round_trip_identifier_to_typed_semantic_external_identifier(
+        self,
+        text: str,
+        expected_type: str,
+        expected_value: str
+    ):
         label_and_layout_line_list = [
-            ('<pubnum>', get_next_layout_line_for_text('PMC1234567'))
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text(text))
         ]
         labeled_model_data_list = get_labeled_model_data_list(
             label_and_layout_line_list,
@@ -486,14 +535,58 @@ class TestCitationTrainingTeiParser:
             labeled_model_data_list
         )
         assert get_tei_xpath_text_content_list(
-            xml_root, f'{BIBL_XPATH}/tei:idno[@type="{SemanticExternalIdentifierTypes.PMCID}"]'
-        ) == ['PMC1234567']
-        tag_result = get_training_tei_parser().parse_training_tei_to_tag_result(
-            xml_root
+            xml_root, f'{BIBL_XPATH}/tei:idno[@type="{expected_type}"]'
+        ) == [text]
+        references = get_semantic_references_for_training_tei_xml(xml_root)
+        assert len(references) == 1
+        assert get_external_identifier_types_and_values(references[0]) == [
+            (expected_type, expected_value)
+        ]
+
+    def test_should_round_trip_multiple_identifiers_of_one_reference(self):
+        label_and_layout_line_list = [
+            ('<title>', get_next_layout_line_for_text('Title 1')),
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text('10.1234/test')),
+            ('O', get_next_layout_line_for_text('and')),
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text('arXiv: 0706.0001')),
+            ('O', get_next_layout_line_for_text('and')),
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text('PMID: 1234567'))
+        ]
+        labeled_model_data_list = get_labeled_model_data_list(
+            label_and_layout_line_list,
+            data_generator=get_data_generator()
         )
-        assert tag_result == [[
-            ('PMC1234567', 'B-<pubnum>')
-        ]]
+        xml_root = get_training_tei_xml_for_model_data_iterable(
+            labeled_model_data_list
+        )
+        references = get_semantic_references_for_training_tei_xml(xml_root)
+        assert len(references) == 1
+        assert get_external_identifier_types_and_values(references[0]) == [
+            (SemanticExternalIdentifierTypes.DOI, '10.1234/test'),
+            (SemanticExternalIdentifierTypes.ARXIV, '0706.0001'),
+            (SemanticExternalIdentifierTypes.PMID, '1234567')
+        ]
+
+    def test_should_merge_directly_adjacent_identifiers_of_one_reference(self):
+        # the parser reconstructs B-/I- from label changes rather than element boundaries,
+        # so two idno elements with only whitespace between them come back as one identifier
+        label_and_layout_line_list = [
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text('10.1234/test')),
+            (IDENTIFIER_LABEL, get_next_layout_line_for_text('PMID: 1234567'))
+        ]
+        labeled_model_data_list = get_labeled_model_data_list(
+            label_and_layout_line_list,
+            data_generator=get_data_generator()
+        )
+        xml_root = get_training_tei_xml_for_model_data_iterable(
+            labeled_model_data_list
+        )
+        assert len(tei_xpath(xml_root, f'{BIBL_XPATH}/tei:idno')) == 2
+        references = get_semantic_references_for_training_tei_xml(xml_root)
+        assert len(references) == 1
+        assert get_external_identifier_types_and_values(references[0]) == [
+            (SemanticExternalIdentifierTypes.DOI, '10.1234/testPMID:1234567')
+        ]
 
     @pytest.mark.parametrize(
         "tei_label,element_path",

--- a/tests/models/extract_test.py
+++ b/tests/models/extract_test.py
@@ -1,5 +1,13 @@
+import logging
+
+import pytest
+
 from sciencebeam_parser.document.layout_document import LayoutBlock
-from sciencebeam_parser.models.extract import get_regex_cleaned_layout_block_with_prefix_suffix
+from sciencebeam_parser.document.semantic_document import SemanticNote, SemanticTitle
+from sciencebeam_parser.models.extract import (
+    SimpleModelSemanticExtractor,
+    get_regex_cleaned_layout_block_with_prefix_suffix
+)
 
 
 class TestGetRegexCleanedLayoutBlockWithPrefixSuffix:
@@ -62,3 +70,72 @@ class TestGetRegexCleanedLayoutBlockWithPrefixSuffix:
         assert prefix_block.text == 'a'
         assert cleaned_block.text == 'b c'
         assert suffix_block.text == 'd'
+
+
+class SimpleExtractor(SimpleModelSemanticExtractor):
+    def iter_semantic_content_for_entity_blocks(self, entity_tokens, **kwargs):
+        return [
+            self.get_semantic_content_for_entity_name(name, layout_block=layout_block)
+            for name, layout_block in entity_tokens
+        ]
+
+
+def _get_semantic_content_for_entity_name(
+    extractor: SimpleModelSemanticExtractor,
+    name: str
+):
+    return extractor.get_semantic_content_for_entity_name(
+        name, layout_block=LayoutBlock.for_text('text 1')
+    )
+
+
+class TestSimpleModelSemanticExtractor:
+    def test_should_use_mapped_semantic_content_class(self):
+        extractor = SimpleExtractor({'<title>': SemanticTitle})
+        assert isinstance(
+            _get_semantic_content_for_entity_name(extractor, '<title>'),
+            SemanticTitle
+        )
+
+    def test_should_keep_unmapped_label_as_note(self):
+        extractor = SimpleExtractor({'<title>': SemanticTitle})
+        semantic_content = _get_semantic_content_for_entity_name(extractor, '<other-label>')
+        assert isinstance(semantic_content, SemanticNote)
+        assert semantic_content.note_type == '<other-label>'
+
+    def test_should_not_warn_about_unmapped_label_without_expected_note_tags(
+        self,
+        caplog: pytest.LogCaptureFixture
+    ):
+        extractor = SimpleExtractor({'<title>': SemanticTitle})
+        with caplog.at_level(logging.WARNING):
+            _get_semantic_content_for_entity_name(extractor, '<other-label>')
+        assert not caplog.records
+
+    @pytest.mark.parametrize("name", ['<note>', 'O', '<other>'])
+    def test_should_not_warn_about_expected_note_or_other_tags(
+        self,
+        name: str,
+        caplog: pytest.LogCaptureFixture
+    ):
+        extractor = SimpleExtractor(
+            {'<title>': SemanticTitle},
+            expected_note_tags={'<note>'}
+        )
+        with caplog.at_level(logging.WARNING):
+            _get_semantic_content_for_entity_name(extractor, name)
+        assert not caplog.records
+
+    def test_should_warn_once_about_an_unexpected_note_tag(
+        self,
+        caplog: pytest.LogCaptureFixture
+    ):
+        extractor = SimpleExtractor(
+            {'<title>': SemanticTitle},
+            expected_note_tags={'<note>'}
+        )
+        with caplog.at_level(logging.WARNING):
+            _get_semantic_content_for_entity_name(extractor, '<idno>')
+            _get_semantic_content_for_entity_name(extractor, '<idno>')
+        assert len(caplog.records) == 1
+        assert '<idno>' in caplog.records[0].getMessage()

--- a/tests/training/cli/generate_data_test.py
+++ b/tests/training/cli/generate_data_test.py
@@ -47,6 +47,7 @@ from sciencebeam_parser.models.table.training_data import (
 from sciencebeam_parser.models.citation.training_data import (
     CitationTeiTrainingDataGenerator
 )
+from sciencebeam_parser.models.citation.labels import IDENTIFIER_LABEL
 from sciencebeam_parser.training.jats.annotated_document import JatsAnnotatedLayoutDocument
 from sciencebeam_parser.training.jats.field_vocab import JatsFieldNames, JatsSubFieldNames
 import sciencebeam_parser.training.cli.generate_data as generate_data_module
@@ -863,6 +864,97 @@ def _make_md(line: LayoutLine, token_idx: int = 0) -> LayoutModelData:
         layout_line=line,
         layout_token=line.tokens[token_idx],
     )
+
+
+def _get_citation_label_list_for_sub_fields(
+    text: str,
+    sub_field_by_token_index: Dict[int, str]
+) -> List[Optional[str]]:
+    line = LayoutLine.for_text(text)
+    citation_doc = LayoutDocument(pages=[LayoutPage(blocks=[LayoutBlock(lines=[line])])])
+    annotated = JatsAnnotatedLayoutDocument(layout_document=citation_doc)
+    for token_index, sub_field in sub_field_by_token_index.items():
+        annotated.set_token_label(
+            line.tokens[token_index], JatsFieldNames.REFERENCE,
+            sub_field_name=sub_field, instance_id=1,
+        )
+    label_fn = CitationModelTrainingDataGenerator().get_jats_label_fn()
+    assert label_fn is not None
+    return [
+        label_fn(annotated, {}, _make_md(line, token_index))
+        for token_index in range(len(line.tokens))
+    ]
+
+
+@log_on_exception
+class TestCitationJatsLabelFn:
+    def test_should_label_identifier_sub_fields_with_the_identifier_label(self):
+        assert _get_citation_label_list_for_sub_fields(
+            'doi 10 unrelated',
+            {1: JatsSubFieldNames.REFERENCE_DOI}
+        ) == [None, IDENTIFIER_LABEL, None]
+
+    def test_should_start_a_new_identifier_when_the_kind_changes(self):
+        # 'doi' and 'pmid' tokens stand for the identifier values; without a B- prefix on the
+        # second one the generator would write both into a single <idno>
+        assert _get_citation_label_list_for_sub_fields(
+            'doi pmid',
+            {
+                0: JatsSubFieldNames.REFERENCE_DOI,
+                1: JatsSubFieldNames.REFERENCE_PMID
+            }
+        ) == [IDENTIFIER_LABEL, 'B-' + IDENTIFIER_LABEL]
+
+    def test_should_not_start_a_new_identifier_within_one_kind(self):
+        assert _get_citation_label_list_for_sub_fields(
+            'doi doi doi',
+            {
+                0: JatsSubFieldNames.REFERENCE_DOI,
+                1: JatsSubFieldNames.REFERENCE_DOI,
+                2: JatsSubFieldNames.REFERENCE_DOI
+            }
+        ) == [IDENTIFIER_LABEL, IDENTIFIER_LABEL, IDENTIFIER_LABEL]
+
+    def test_should_not_start_a_new_identifier_after_unlabelled_text(self):
+        # the unlabelled token already closes the <idno> element
+        assert _get_citation_label_list_for_sub_fields(
+            'doi and pmid',
+            {
+                0: JatsSubFieldNames.REFERENCE_DOI,
+                2: JatsSubFieldNames.REFERENCE_PMID
+            }
+        ) == [IDENTIFIER_LABEL, None, IDENTIFIER_LABEL]
+
+    def test_should_not_start_a_new_identifier_across_references(self):
+        # each reference is its own training document, so the first identifier of the next
+        # one needs no prefix even though its kind differs from the previous reference's
+        line = LayoutLine.for_text('pmid doi')
+        citation_doc = LayoutDocument(pages=[LayoutPage(blocks=[LayoutBlock(lines=[line])])])
+        annotated = JatsAnnotatedLayoutDocument(layout_document=citation_doc)
+        annotated.set_token_label(
+            line.tokens[0], JatsFieldNames.REFERENCE,
+            sub_field_name=JatsSubFieldNames.REFERENCE_PMID, instance_id=1,
+        )
+        annotated.set_token_label(
+            line.tokens[1], JatsFieldNames.REFERENCE,
+            sub_field_name=JatsSubFieldNames.REFERENCE_DOI, instance_id=2,
+        )
+        label_fn = CitationModelTrainingDataGenerator().get_jats_label_fn()
+        assert label_fn is not None
+        assert [
+            label_fn(annotated, {}, _make_md(line, 0)),
+            label_fn(annotated, {}, _make_md(line, 1))
+        ] == [IDENTIFIER_LABEL, IDENTIFIER_LABEL]
+
+    def test_should_not_start_a_new_identifier_after_another_label(self):
+        assert _get_citation_label_list_for_sub_fields(
+            'doi 2020 pmid',
+            {
+                0: JatsSubFieldNames.REFERENCE_DOI,
+                1: JatsSubFieldNames.REFERENCE_YEAR,
+                2: JatsSubFieldNames.REFERENCE_PMID
+            }
+        ) == [IDENTIFIER_LABEL, '<date>', IDENTIFIER_LABEL]
 
 
 @log_on_exception


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/145

**Why this matters**: a citation model trained on our generated data labels DOIs `<idno>`, and the
extractor has no mapping for that label — so every DOI it predicts becomes an anonymous note. It never
becomes a `SemanticExternalIdentifier`, never reaches the TEI as `reference_doi`, and doesn't count
towards `is_reference_valid`. Over the committed corpus that was **583 of 589 identifier elements**
(5431 of 5446 tokens): the field the benchmark scores was being thrown away after training had already
paid for it.

Measured over the same corpus, before and after, across 3304 references:

| | typed DOI identifiers extracted |
| --- | --- |
| before | 38 — all of them `<web>`-derived, since `<idno>` produced none |
| after | 616 |

**This is GROBID's convention, not a new one.** `TEICitationSaxParser` maps both `idno` and `pubnum`
elements to a single `<pubnum>` label and leaves the type unused (`// TBD: keep the idno type for
further exploitation`); `CitationParser` types the prediction afterwards via
`BiblioItem.checkIdentifier()`. DOI and PMID stay separate where it counts — as typed values,
`<idno type="…">` in the output TEI, and separately scorable fields. Dropping the extra label also
brings the generated label set to GROBID's 19, so the two corpora can finally be trained together
without carrying two conventions.

### What changes

- `models/citation/labels.py` states the label set, the identifier label and the labels that
  legitimately stay notes. The training TEI paths, the JATS sub-field map, the extractor and the
  benchmark's `reference_doi` analysis all read from it, and a test fails if they drift apart.
- The training TEI parser maps **any** `idno` element back to the identifier label instead of
  enumerating the five types our detection can produce. GROBID's own training TEI spells them
  `type="arXiv"` and `type="PMC"` and includes ISSN and ISBN — an enumerated list would raise on its
  corpus.
- An unmapped citation label is no longer silently swallowed: the extractor declares which labels are
  notes and warns once for anything else, and a test asserts every label in the set is either mapped or
  declared.
- The JATS label function starts a new identifier when the sub-field kind changes, so a DOI directly
  followed by a PMID is no longer written as one `<idno>` whose value carries both — that produced a
  *corrupted* DOI, which scores worse than a missing one.

### No serving change

GROBID's shipped models never emit `<idno>`, so extraction behaviour for current models is unchanged.
`AbstractTrainingTeiParser` has one production caller, `generate_delft_data` — nothing in the inference
path.

### Verified

122 citation tests including a DOI/arXiv/PMID/PMCID round trip through generation → parsing →
extraction, and a coverage test over the whole label set; 948 tests across `tests/models`,
`tests/training`, `tests/document`; flake8, pylint and mypy clean. All 88 committed TEI files parse
without exception, and `<idno>` disappears from the generated label set.