### PR TITLE
Make model predictions inspectable as JSON again

### DIFF
--- a/sciencebeam_parser/service/api/routers/models.py
+++ b/sciencebeam_parser/service/api/routers/models.py
@@ -176,9 +176,9 @@ class ModelResponseRouterFactory:
                 if not len(texts):  # pylint: disable=len-as-condition
                     tag_result = []
                 else:
-                    texts = texts.tolist()
                     tag_result = self.model.predict_labels(
-                        texts=texts, features=features.tolist(), output_format=None
+                        texts=texts.tolist(), features=features.tolist(),
+                        output_format=None
                     )
                 LOGGER.debug('tag_result: %s', tag_result)
                 formatted_tag_result_iterable = iter_format_tag_result(

--- a/tests/service/api/models_router_test.py
+++ b/tests/service/api/models_router_test.py
@@ -1,9 +1,16 @@
+import json
 import logging
 from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
+from sciencebeam_trainer_delft.sequence_labelling.reader import load_data_crf_lines
+from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
+    TagLabelFormats,
+    TagOutputFormats,
+    iter_format_tag_result
+)
 
 from sciencebeam_parser.models.data import DEFAULT_APP_FEATURES_CONTEXT
 from sciencebeam_parser.service.api.routers.models import create_models_router
@@ -51,3 +58,42 @@ class TestGetFeatureNames:
         feature_names = response.json()['feature_names']
         assert feature_names[0] == 'token_text'
         assert 'sentence_token_relative_position' in feature_names
+
+
+class TestRaggedTagResultFormatting:
+    """The json formatter calls np.array(texts), which fails on a ragged list.
+
+    `load_data_crf_lines` returns dtype=object arrays that survive that call, so
+    the router has to pass those arrays through rather than a nested list — one
+    `.tolist()` too early breaks /api/models/citation?output_format=json for any
+    document with references of differing lengths, on any engine.
+    """
+    def test_should_format_sequences_of_differing_lengths_as_json(self):
+        data_lines = ['a f x', 'b f x', '', 'c f x', '', 'd f x', 'e f x']
+        texts, features = load_data_crf_lines(data_lines)
+        tag_result = [[(token, 'O') for token in sequence] for sequence in texts.tolist()]
+        content = ''.join(iter_format_tag_result(
+            tag_result,
+            output_format=TagOutputFormats.JSON,
+            label_format=TagLabelFormats.GROBID,
+            expected_tag_result=None,
+            texts=texts,
+            features=features,
+            model_name='citation'
+        ))
+        assert [len(sequence) for sequence in json.loads(content)['texts']] == [2, 1, 2]
+
+    def test_should_fail_on_a_nested_list_rather_than_an_object_array(self):
+        data_lines = ['a f x', 'b f x', '', 'c f x']
+        texts, features = load_data_crf_lines(data_lines)
+        tag_result = [[(token, 'O') for token in sequence] for sequence in texts.tolist()]
+        with pytest.raises(ValueError, match='inhomogeneous'):
+            ''.join(iter_format_tag_result(
+                tag_result,
+                output_format=TagOutputFormats.JSON,
+                label_format=TagLabelFormats.GROBID,
+                expected_tag_result=None,
+                texts=texts.tolist(),
+                features=features,
+                model_name='citation'
+            ))


### PR DESCRIPTION
`/api/models/<name>?output_format=json` is the endpoint you reach for when
checking by hand what a model predicted. It raised a numpy "inhomogeneous
shape" ValueError for any document whose sequences differ in length — for the
citation model, every document with more than one reference. Only the JSON
format was affected; `output_format=data` returns before the formatter is
reached, which is why this stayed hidden.

The formatter needs the `dtype=object` arrays that `load_data_crf_lines`
returns, because those survive its internal `np.array(texts)`. The router
flattened them to a nested list one step too early, so the formatter got
something numpy refuses to build an array from. It now passes the arrays
through and converts only for `predict_labels`, which wants lists. Not
engine-specific: `texts` is built before prediction, so wapiti and delft were
affected identically.

Tests pin both directions of that seam — an object array formats, a nested list
raises — so the constraint is cheap to check without loading a real model.