### PR TITLE
Improved telemetry, by group model calls under a document parent span

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --dev \
     --extra cpu \
     --extra delft \
-    --extra cv
+    --extra cv \
+    --extra telemetry
 
 COPY sciencebeam_parser ./sciencebeam_parser
 COPY delft ./delft

--- a/doc/llm_engine.md
+++ b/doc/llm_engine.md
@@ -180,6 +180,12 @@ one backend's configuration into the engine.
 The response body is attached to the span even when it fails to decode, which is the point: a
 truncated or malformed response is visible rather than inferred from an exception.
 
+A call made while serving a request nests under a `process_document` span naming the document, so a
+trace says which document it is about. The log line for a completed call names its trace id, which
+is what joins the log to the prompt and response on the span.
+
+Tracing is not specific to this engine and lives in `utils/telemetry.py`.
+
 **A span carrying prompt text is a copy of manuscript text.** Sending it to a collector on localhost
 is not a new disclosure when the same text is already going to the model, but sending it anywhere
 else is. Set `record_trace_content: false` in the model config to keep the metrics and drop the

--- a/sciencebeam_parser/app/parser.py
+++ b/sciencebeam_parser/app/parser.py
@@ -35,6 +35,7 @@ from sciencebeam_parser.utils.lazy import LazyLoaded
 from sciencebeam_parser.utils.media_types import (
     MediaTypes
 )
+from sciencebeam_parser.utils.telemetry import span
 from sciencebeam_parser.utils.text import normalize_text
 from sciencebeam_parser.utils.tokenizer import get_tokenized_tokens
 from sciencebeam_parser.processors.fulltext.api import (
@@ -487,11 +488,16 @@ class ScienceBeamParserSessionSource(_ScienceBeamParserSessionDerivative):
         self,
         session: 'ScienceBeamParserBaseSession',
         source_path: str,
-        source_media_type: str
+        source_media_type: str,
+        source_name: Optional[str] = None
     ):
         super().__init__(session=session)
         self.source_path = source_path
         self.source_media_type = source_media_type
+        # The uploaded name, which `source_path` has already lost: the request
+        # writes the upload to a temporary `source.file`. Only used to say which
+        # document a trace or a log line is about.
+        self.source_name = source_name
         self.lazy_pdf_path = LazyLoaded[str](self._get_or_convert_to_pdf_path)
         self.lazy_alto_xml_path = LazyLoaded[str](self._parse_to_alto_xml)
         self.lazy_parsed_layout_document = LazyLoaded[
@@ -582,13 +588,22 @@ class ScienceBeamParserSessionSource(_ScienceBeamParserSessionDerivative):
         self,
         response_media_type: str
     ) -> str:
-        if response_media_type == MediaTypes.PDF:
-            return self.lazy_pdf_path.get()
-        if response_media_type == MediaTypes.ALTO_XML:
-            return self.lazy_alto_xml_path.get()
-        return self.get_parsed_layout_document().get_local_file_for_response_media_type(
-            response_media_type
-        )
+        # The outermost step of processing one document, and so the span
+        # everything below it nests under — model calls included, which is what
+        # makes a trace answer "which document was this?" on its own.
+        with span('process_document', {
+            'sciencebeam.document.name': self.source_name,
+            'sciencebeam.document.source_media_type': self.source_media_type,
+            'sciencebeam.document.response_media_type': response_media_type,
+        }, tracer_name=__name__):
+            if response_media_type == MediaTypes.PDF:
+                return self.lazy_pdf_path.get()
+            if response_media_type == MediaTypes.ALTO_XML:
+                return self.lazy_alto_xml_path.get()
+            return (
+                self.get_parsed_layout_document()
+                .get_local_file_for_response_media_type(response_media_type)
+            )
 
 
 class ScienceBeamParserSession(ScienceBeamParserBaseSession):
@@ -599,12 +614,14 @@ class ScienceBeamParserSession(ScienceBeamParserBaseSession):
     def get_source(
         self,
         source_path: str,
-        source_media_type: str
+        source_media_type: str,
+        source_name: Optional[str] = None
     ) -> ScienceBeamParserSessionSource:
         return ScienceBeamParserSessionSource(
             self,
             source_path=source_path,
-            source_media_type=source_media_type
+            source_media_type=source_media_type,
+            source_name=source_name
         )
 
 

--- a/sciencebeam_parser/models/llm/model_impl.py
+++ b/sciencebeam_parser/models/llm/model_impl.py
@@ -1,5 +1,6 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from typing import List, Optional, Tuple
 
 from sciencebeam_parser.models.llm.client import (
@@ -31,6 +32,7 @@ from sciencebeam_parser.models.llm.values import (
     render_numbered_references
 )
 from sciencebeam_parser.models.model_impl import ModelImpl
+from sciencebeam_parser.utils.telemetry import get_trace_id
 
 
 LOGGER = logging.getLogger(__name__)
@@ -138,9 +140,20 @@ class LlmModelImpl(ModelImpl):
             # Batches are independent, so the wall-clock is the slowest batch
             # rather than their sum. Order is preserved by mapping rather than
             # completion order, and the first exception propagates.
+            #
+            # Each batch runs in a copy of the calling context, because a worker
+            # thread starts with none: without this the span for a batch has no
+            # parent, and a run becomes a flat list of calls belonging to no
+            # document. The copies are taken here rather than in the worker,
+            # where there would be nothing left to copy, and one per batch,
+            # since a context cannot be entered twice at once.
             with ThreadPoolExecutor(max_workers=workers) as pool:
                 per_batch = list(pool.map(
-                    self._predict_labels_splitting_on_truncation, batches
+                    lambda context, batch: context.run(
+                        self._predict_labels_splitting_on_truncation, batch
+                    ),
+                    [copy_context() for _ in batches],
+                    batches
                 ))
         return [labelled for batch in per_batch for labelled in batch]
 
@@ -326,9 +339,10 @@ class LlmModelImpl(ModelImpl):
                     content, tokens, line_status_values
                 )
         LOGGER.info(
-            'llm labelled %d tokens over %d lines (model=%r provider=%r)',
+            'llm labelled %d tokens over %d lines'
+            ' (model=%r provider=%r trace=%s)',
             len(tokens), max(line_numbers) + 1, self.config.model,
-            response_json.get('provider')
+            response_json.get('provider'), get_trace_id(span) or '-'
         )
         return labeled
 
@@ -396,8 +410,9 @@ class LlmModelImpl(ModelImpl):
             span.set_attribute('sciencebeam.unanswered_references', len(missing))
             self._check_dropped_fields(dropped, len(token_lists))
         LOGGER.info(
-            'llm labelled %d references, %d tokens (model=%r provider=%r)',
+            'llm labelled %d references, %d tokens'
+            ' (model=%r provider=%r trace=%s)',
             len(token_lists), token_count, self.config.model,
-            response_json.get('provider')
+            response_json.get('provider'), get_trace_id(span) or '-'
         )
         return labeled, missing

--- a/sciencebeam_parser/models/llm/telemetry.py
+++ b/sciencebeam_parser/models/llm/telemetry.py
@@ -1,21 +1,12 @@
-import importlib
 import json
 import logging
-import os
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, Mapping, Optional, Protocol
+from typing import Any, Dict, Iterator, Mapping, Optional
+
+from sciencebeam_parser.utils.telemetry import NoOpSpan, SpanLike, get_tracer
 
 
 LOGGER = logging.getLogger(__name__)
-
-# Standard OTLP configuration, read by the exporter itself. Nothing here names a
-# backend; Phoenix is only what happens to listen in development.
-OTLP_ENDPOINT_ENV_NAMES = (
-    'OTEL_EXPORTER_OTLP_ENDPOINT',
-    'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
-)
-
-SERVICE_NAME = 'sciencebeam-parser'
 
 OPERATION_NAME = 'chat'
 
@@ -45,77 +36,6 @@ OPENINFERENCE_INPUT_VALUE = 'input.value'
 OPENINFERENCE_OUTPUT_VALUE = 'output.value'
 
 
-class SpanLike(Protocol):
-    def set_attribute(self, key: str, value: Any) -> None:
-        ...
-
-
-class NoOpSpan:
-    def set_attribute(self, key: str, value: Any) -> None:
-        pass
-
-
-def is_configured() -> bool:
-    return any(os.environ.get(name) for name in OTLP_ENDPOINT_ENV_NAMES)
-
-
-def get_configured_endpoint() -> Optional[str]:
-    return (
-        os.environ.get('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT')
-        or os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT')
-    )
-
-
-def _import_optional(name: str):
-    try:
-        return importlib.import_module(name)
-    except ImportError:
-        return None
-
-
-def _get_tracer():
-    """None unless opentelemetry is installed and an OTLP endpoint is set.
-
-    Absent either, the engine emits nothing and behaves identically — tracing is
-    an optional extra, not a dependency of the default install.
-    """
-    if not is_configured():
-        return None
-    trace = _import_optional('opentelemetry.trace')
-    if trace is None:
-        LOGGER.info(
-            'an otlp endpoint is set but opentelemetry is not installed;'
-            ' install the "telemetry" extra to emit spans'
-        )
-        return None
-    _ensure_tracer_provider(trace)
-    return trace.get_tracer(__name__)
-
-
-def _ensure_tracer_provider(trace) -> None:
-    current = trace.get_tracer_provider()
-    if type(current).__name__ not in ('DefaultTracerProvider', 'ProxyTracerProvider'):
-        return
-    resources = _import_optional('opentelemetry.sdk.resources')
-    sdk_trace = _import_optional('opentelemetry.sdk.trace')
-    export = _import_optional('opentelemetry.sdk.trace.export')
-    otlp = _import_optional(
-        'opentelemetry.exporter.otlp.proto.http.trace_exporter'
-    )
-    if not all((resources, sdk_trace, export, otlp)):
-        LOGGER.info('no opentelemetry sdk or otlp exporter; not configuring a provider')
-        return
-    provider = sdk_trace.TracerProvider(
-        resource=resources.Resource.create({'service.name': SERVICE_NAME})
-    )
-    provider.add_span_processor(export.BatchSpanProcessor(otlp.OTLPSpanExporter()))
-    trace.set_tracer_provider(provider)
-    LOGGER.info(
-        'configured otlp tracing for %r, exporting to %s',
-        SERVICE_NAME, get_configured_endpoint()
-    )
-
-
 def get_invocation_parameters(config) -> str:
     return json.dumps({
         'temperature': config.temperature,
@@ -128,7 +48,7 @@ def get_invocation_parameters(config) -> str:
 
 @contextmanager
 def llm_span(config, prompt: str, record_content: bool = True) -> Iterator[SpanLike]:
-    tracer = _get_tracer()
+    tracer = get_tracer(__name__)
     if tracer is None:
         yield NoOpSpan()
         return

--- a/sciencebeam_parser/service/api/dependencies.py
+++ b/sciencebeam_parser/service/api/dependencies.py
@@ -116,6 +116,33 @@ def get_sciencebeam_parser_session_dependency_factory(
     return get_session
 
 
+def get_session_source_for_data_wrapper(
+    session: ScienceBeamParserSession,
+    data_wrapper: MediaDataWrapper
+) -> ScienceBeamParserSessionSource:
+    """Turn an upload into a session source, for every route that takes one.
+
+    Shared rather than repeated, because a route with its own copy is a route
+    that silently stops logging or naming the document when this one changes.
+    """
+    data_wrapper = get_data_wrapper_with_improved_media_type_or_filename(
+        data_wrapper
+    )
+    # The uploaded name is the only thing tying the rest of this request's log
+    # lines to a document; without it a run is anonymous documents.
+    LOGGER.info(
+        'processing document: filename=%r media_type=%r session=%s',
+        data_wrapper.filename, data_wrapper.media_type, session.temp_path
+    )
+    source_path = session.temp_path / "source.file"
+    source_path.write_bytes(data_wrapper.data)
+    return session.get_source(
+        source_path=str(source_path),
+        source_media_type=data_wrapper.media_type,
+        source_name=data_wrapper.filename,
+    )
+
+
 def get_sciencebeam_parser_session_source_dependency_factory(
     **session_kwargs,
 ) -> ScienceBeamParserSessionSourceDependencyFactory:
@@ -129,16 +156,7 @@ def get_sciencebeam_parser_session_source_dependency_factory(
         ],
         data_wrapper: Annotated[MediaDataWrapper, Depends(get_media_data_wrapper)],
     ) -> Iterator[ScienceBeamParserSessionSource]:
-        data_wrapper = get_data_wrapper_with_improved_media_type_or_filename(
-            data_wrapper
-        )
-        source_path = session.temp_path / "source.file"
-        source_path.write_bytes(data_wrapper.data)
-
-        yield session.get_source(
-            source_path=str(source_path),
-            source_media_type=data_wrapper.media_type,
-        )
+        yield get_session_source_for_data_wrapper(session, data_wrapper)
 
     return get_source
 

--- a/sciencebeam_parser/service/api/routers/convert.py
+++ b/sciencebeam_parser/service/api/routers/convert.py
@@ -13,7 +13,8 @@ from sciencebeam_parser.service.api.dependencies import (
     ScienceBeamParserSessionSourceDependencyFactory,
     assert_and_get_first_accept_matching_media_type_factory,
     get_media_data_wrapper,
-    get_sciencebeam_parser
+    get_sciencebeam_parser,
+    get_session_source_for_data_wrapper
 )
 from sciencebeam_parser.service.api.routers.docs import (
     PDF_CONTENT_DOC,
@@ -21,10 +22,7 @@ from sciencebeam_parser.service.api.routers.docs import (
     TEI_AND_JATS_ZIP_CONTENT_DOC
 )
 from sciencebeam_parser.service.api.routers.utils import get_processed_source_to_response_media_type
-from sciencebeam_parser.utils.data_wrapper import (
-    MediaDataWrapper,
-    get_data_wrapper_with_improved_media_type_or_filename
-)
+from sciencebeam_parser.utils.data_wrapper import MediaDataWrapper
 from sciencebeam_parser.utils.media_types import MediaTypes
 from sciencebeam_parser.utils.text import parse_comma_separated_value
 
@@ -73,16 +71,7 @@ def get_convert_sciencebeam_parser_session_source_dependency_factory(
         ],
         data_wrapper: Annotated[MediaDataWrapper, Depends(get_media_data_wrapper)],
     ) -> Iterator[ScienceBeamParserSessionSource]:
-        data_wrapper = get_data_wrapper_with_improved_media_type_or_filename(
-            data_wrapper
-        )
-        source_path = session.temp_path / "source.file"
-        source_path.write_bytes(data_wrapper.data)
-
-        yield session.get_source(
-            source_path=str(source_path),
-            source_media_type=data_wrapper.media_type,
-        )
+        yield get_session_source_for_data_wrapper(session, data_wrapper)
 
     return get_source
 

--- a/sciencebeam_parser/service/api/routers/models.py
+++ b/sciencebeam_parser/service/api/routers/models.py
@@ -46,6 +46,7 @@ from sciencebeam_parser.models.model import Model
 from sciencebeam_parser.service.api.dependencies import (
     get_sciencebeam_parser_session_source_dependency_factory
 )
+from sciencebeam_parser.utils.telemetry import span
 
 
 LOGGER = logging.getLogger(__name__)
@@ -131,7 +132,24 @@ class ModelResponseRouterFactory:
     ) -> Iterable[LayoutDocument]:
         return [layout_document]
 
-    def handle_post(  # pylint: disable=too-many-locals
+    def handle_post(
+        self,
+        source: ScienceBeamParserSessionSource,
+        output_format: str,
+        filter_params: Optional[dict] = None
+    ):
+        # The same span name as the full pipeline, so one query finds every
+        # document however the parser was entered. The model attribute is what
+        # tells a single-model request apart from a whole document.
+        with span('process_document', {
+            'sciencebeam.document.name': source.source_name,
+            'sciencebeam.document.source_media_type': source.source_media_type,
+            'sciencebeam.model.name': self.model_name,
+            'sciencebeam.model.output_format': output_format,
+        }, tracer_name=__name__):
+            return self._handle_post(source, output_format, filter_params)
+
+    def _handle_post(  # pylint: disable=too-many-locals
         self,
         source: ScienceBeamParserSessionSource,
         output_format: str,

--- a/sciencebeam_parser/training/cli/generate_data.py
+++ b/sciencebeam_parser/training/cli/generate_data.py
@@ -1453,7 +1453,10 @@ def get_layout_document_for_source_filename(
             source_filename,
             auto_decompress=True
         ) as local_source_filename:
-            source = session.get_source(local_source_filename, MediaTypes.PDF)
+            source = session.get_source(
+                local_source_filename, MediaTypes.PDF,
+                source_name=source_filename
+            )
             layout_document = source.get_layout_document()
             return layout_document
 

--- a/sciencebeam_parser/utils/telemetry.py
+++ b/sciencebeam_parser/utils/telemetry.py
@@ -1,0 +1,135 @@
+"""OpenTelemetry tracing, for any part of the parser rather than one model engine.
+
+Optional throughout: without the `telemetry` extra installed, and without an
+OTLP endpoint set, nothing is emitted and every caller behaves identically.
+"""
+import importlib
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional, Protocol
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Standard OTLP configuration, read by the exporter itself. Nothing here names a
+# backend; Phoenix is only what happens to listen in development.
+OTLP_ENDPOINT_ENV_NAMES = (
+    'OTEL_EXPORTER_OTLP_ENDPOINT',
+    'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+)
+
+SERVICE_NAME = 'sciencebeam-parser'
+
+
+class SpanLike(Protocol):
+    def set_attribute(self, key: str, value: Any) -> None:
+        ...
+
+
+class NoOpSpan:
+    def set_attribute(self, key: str, value: Any) -> None:
+        pass
+
+
+def is_configured() -> bool:
+    return any(os.environ.get(name) for name in OTLP_ENDPOINT_ENV_NAMES)
+
+
+def get_configured_endpoint() -> Optional[str]:
+    return (
+        os.environ.get('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT')
+        or os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT')
+    )
+
+
+def _import_optional(name: str):
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
+
+
+def get_tracer(name: str = __name__):
+    """None unless opentelemetry is installed and an OTLP endpoint is set.
+
+    Absent either, callers emit nothing and behave identically — tracing is an
+    optional extra, not a dependency of the default install.
+    """
+    if not is_configured():
+        return None
+    trace = _import_optional('opentelemetry.trace')
+    if trace is None:
+        LOGGER.info(
+            'an otlp endpoint is set but opentelemetry is not installed;'
+            ' install the "telemetry" extra to emit spans'
+        )
+        return None
+    _ensure_tracer_provider(trace)
+    return trace.get_tracer(name)
+
+
+def _ensure_tracer_provider(trace) -> None:
+    current = trace.get_tracer_provider()
+    if type(current).__name__ not in ('DefaultTracerProvider', 'ProxyTracerProvider'):
+        return
+    resources = _import_optional('opentelemetry.sdk.resources')
+    sdk_trace = _import_optional('opentelemetry.sdk.trace')
+    export = _import_optional('opentelemetry.sdk.trace.export')
+    otlp = _import_optional(
+        'opentelemetry.exporter.otlp.proto.http.trace_exporter'
+    )
+    if not all((resources, sdk_trace, export, otlp)):
+        LOGGER.info('no opentelemetry sdk or otlp exporter; not configuring a provider')
+        return
+    provider = sdk_trace.TracerProvider(
+        resource=resources.Resource.create({'service.name': SERVICE_NAME})
+    )
+    provider.add_span_processor(export.BatchSpanProcessor(otlp.OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    LOGGER.info(
+        'configured otlp tracing for %r, exporting to %s',
+        SERVICE_NAME, get_configured_endpoint()
+    )
+
+
+def get_trace_id(active_span: SpanLike) -> Optional[str]:
+    """The span's trace id, so a log line can name the trace holding its content.
+
+    What a span carries and what the log carries are different halves of the
+    same call, and this is what joins them. `None` when tracing is off, when the
+    log line has nothing to point at anyway.
+    """
+    get_span_context = getattr(active_span, 'get_span_context', None)
+    if get_span_context is None:
+        return None
+    span_context = get_span_context()
+    trace_id = getattr(span_context, 'trace_id', None)
+    if not trace_id:
+        return None
+    return format(trace_id, '032x')
+
+
+@contextmanager
+def span(
+    name: str,
+    attributes: Optional[Mapping[str, Any]] = None,
+    tracer_name: str = __name__
+) -> Iterator[SpanLike]:
+    """A current span, or a no-op one when tracing is off.
+
+    Made current rather than merely started, so work underneath it nests without
+    every layer having to pass a parent. A span crossing into a thread pool is
+    the exception: OpenTelemetry keeps the current span in a context variable,
+    which a worker thread does not inherit, so the pool has to carry the context
+    over itself.
+    """
+    tracer = get_tracer(tracer_name)
+    if tracer is None:
+        yield NoOpSpan()
+        return
+    with tracer.start_as_current_span(name) as started:
+        for key, value in (attributes or {}).items():
+            if value is not None:
+                started.set_attribute(key, value)
+        yield started

--- a/tests/app/parser_test.py
+++ b/tests/app/parser_test.py
@@ -1,7 +1,8 @@
 import logging
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, List, Tuple
 from zipfile import ZipFile
 
 from lxml import etree
@@ -239,6 +240,39 @@ class TestScienceBeamParser:
             fulltext_models.preload.assert_called()
 
     class TestGetLocalFileForResponseMediaType:
+        def test_should_name_the_document_on_the_span(
+            self,
+            sciencebeam_parser_session: ScienceBeamParserSession,
+            doc_converter_wrapper_mock: MagicMock,
+            request_temp_path: Path,
+            monkeypatch: pytest.MonkeyPatch
+        ):
+            recorded: List[Tuple[str, dict]] = []
+
+            @contextmanager
+            def recording_span(name: str, attributes=None, **_kwargs):
+                recorded.append((name, dict(attributes or {})))
+                yield MagicMock(name='span')
+
+            monkeypatch.setattr(
+                'sciencebeam_parser.app.parser.span', recording_span
+            )
+            docx_path = request_temp_path / 'test.docx'
+            doc_converter_wrapper_mock.convert.return_value = 'test.pdf'
+            sciencebeam_parser_session.get_source(
+                str(docx_path),
+                MediaTypes.DOCX,
+                source_name='the-uploaded-name.docx'
+            ).get_local_file_for_response_media_type(MediaTypes.PDF)
+            assert recorded == [(
+                'process_document',
+                {
+                    'sciencebeam.document.name': 'the-uploaded-name.docx',
+                    'sciencebeam.document.source_media_type': MediaTypes.DOCX,
+                    'sciencebeam.document.response_media_type': MediaTypes.PDF,
+                }
+            )]
+
         def test_should_raise_for_unsupported_request_media_type(
             self,
             sciencebeam_parser_session: ScienceBeamParserSession,

--- a/tests/models/llm/model_impl_test.py
+++ b/tests/models/llm/model_impl_test.py
@@ -1,5 +1,6 @@
 import json
 import threading
+from contextvars import ContextVar
 from typing import Any, List, Mapping, Optional
 
 import pytest
@@ -13,6 +14,7 @@ from sciencebeam_parser.models.llm.decode import (
 from sciencebeam_parser.models.llm.features import get_feature_column_index
 from sciencebeam_parser.models.llm.model_impl import LlmModelImpl
 from sciencebeam_parser.models.llm.values import render_numbered_references
+from sciencebeam_parser.utils.telemetry import span
 
 
 CONFIG = {
@@ -633,6 +635,91 @@ class TestCitationConcurrency:
         assert [tokens[0] for tokens in token_lists] == [
             labelled[0][0] for labelled in result
         ]
+
+    def test_should_carry_the_calling_context_into_each_worker(self):
+        """What makes a batch's span nest under the document's.
+
+        A worker thread starts with no context, so the current span would
+        otherwise be absent there and every batch would begin its own trace.
+        Asserted on a plain context variable rather than on a span, so it holds
+        whether or not opentelemetry is installed.
+        """
+        current_document: ContextVar[str] = ContextVar('current_document')
+        seen: List[str] = []
+        lock = threading.Lock()
+
+        class ContextObservingClient(FakeClient):
+            def get_completion(self, prompt: str, response_schema):
+                with lock:
+                    seen.append(current_document.get('missing'))
+                return super().get_completion(prompt, response_schema)
+
+        token_lists = [['Alpha'], ['Bravo'], ['Charlie']]
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config({
+                **CITATION_CONFIG,
+                'max_references_per_request': 1,
+                'max_concurrent_requests': 3,
+            }),
+            client=ContextObservingClient(content=batched([]))
+        )
+        current_document.set('example.pdf')
+        model_impl.predict_labels(token_lists, no_features(token_lists))
+        assert seen == ['example.pdf'] * len(token_lists)
+
+    def test_should_nest_parallel_batch_spans_under_the_document(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The same propagation, asserted against opentelemetry itself.
+
+        The tracer is replaced rather than a global provider installed, since
+        the global one can only be set once per process and would leak into
+        every other test.
+        """
+        # Imported here rather than at the top, because the sdk is an optional
+        # extra and this module has to import without it.
+        # pylint: disable=import-outside-toplevel
+        pytest.importorskip('opentelemetry.sdk')
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        for module in (
+            'sciencebeam_parser.utils.telemetry',
+            'sciencebeam_parser.models.llm.telemetry'
+        ):
+            monkeypatch.setattr(
+                f'{module}.get_tracer', lambda name=None: provider.get_tracer(__name__)
+            )
+
+        token_lists = [['Alpha'], ['Bravo'], ['Charlie'], ['Delta']]
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config({
+                **CITATION_CONFIG,
+                'max_references_per_request': 1,
+                'max_concurrent_requests': 4,
+            }),
+            client=FakeClient(content=batched([]))
+        )
+        with span('process_document', {'sciencebeam.document.name': 'example.pdf'}):
+            model_impl.predict_labels(token_lists, no_features(token_lists))
+
+        spans = exporter.get_finished_spans()
+        document = [one for one in spans if one.name == 'process_document']
+        calls = [one for one in spans if one.name != 'process_document']
+        assert len(document) == 1
+        assert len(calls) == len(token_lists)
+        assert all(
+            one.parent is not None
+            and one.parent.span_id == document[0].context.span_id
+            for one in calls
+        )
+        assert len({one.context.trace_id for one in spans}) == 1
 
     def test_should_make_one_call_per_batch_when_parallel(self):
         token_lists = [['Alpha'], ['Bravo'], ['Charlie']]

--- a/tests/models/llm/model_impl_test.py
+++ b/tests/models/llm/model_impl_test.py
@@ -677,8 +677,9 @@ class TestCitationConcurrency:
         every other test.
         """
         # Imported here rather than at the top, because the sdk is an optional
-        # extra and this module has to import without it.
-        # pylint: disable=import-outside-toplevel
+        # extra: this module has to import without it, and the lint image does
+        # not install it.
+        # pylint: disable=import-outside-toplevel,import-error
         pytest.importorskip('opentelemetry.sdk')
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor

--- a/tests/models/llm/telemetry_test.py
+++ b/tests/models/llm/telemetry_test.py
@@ -14,9 +14,7 @@ from sciencebeam_parser.models.llm.telemetry import (
     OPENINFERENCE_OUTPUT_VALUE,
     OPENINFERENCE_SPAN_KIND,
     OPENINFERENCE_TOKEN_COUNT_COMPLETION,
-    get_configured_endpoint,
     get_invocation_parameters,
-    is_configured,
     llm_span,
     set_response_attributes
 )
@@ -52,37 +50,6 @@ class RecordingSpan:
 def _no_endpoint(monkeypatch: pytest.MonkeyPatch):
     for name in ('OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'):
         monkeypatch.delenv(name, raising=False)
-
-
-class TestIsConfigured:
-    @pytest.mark.usefixtures('no_endpoint')
-    def test_should_be_false_without_an_endpoint(self):
-        assert is_configured() is False
-
-    def test_should_be_true_with_an_otlp_endpoint(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318')
-        assert is_configured() is True
-
-    @pytest.mark.usefixtures('no_endpoint')
-    def test_should_ignore_a_backend_specific_endpoint_variable(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.setenv('PHOENIX_COLLECTOR_ENDPOINT', 'http://localhost:6006')
-        assert is_configured() is False
-
-
-class TestGetConfiguredEndpoint:
-    @pytest.mark.usefixtures('no_endpoint')
-    def test_should_be_none_without_any_endpoint(self):
-        assert get_configured_endpoint() is None
-
-    @pytest.mark.usefixtures('no_endpoint')
-    def test_should_prefer_the_traces_endpoint(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://base:4318')
-        monkeypatch.setenv(
-            'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'http://traces:4318/v1/traces'
-        )
-        assert get_configured_endpoint() == 'http://traces:4318/v1/traces'
 
 
 class TestLlmSpan:

--- a/tests/service/api/app_test.py
+++ b/tests/service/api/app_test.py
@@ -174,6 +174,29 @@ class TestApiApp:
             }, headers={'Accept': 'media/unsupported'})
             assert response.status_code == 406
 
+        def test_should_log_the_uploaded_filename(
+            self,
+            test_client: TestClient,
+            get_local_file_for_response_media_type_mock: MagicMock,
+            request_temp_path: Path,
+            caplog: pytest.LogCaptureFixture
+        ):
+            expected_output_path = request_temp_path / 'result.xml'
+            expected_output_path.write_bytes(TEI_XML_CONTENT_1)
+            get_local_file_for_response_media_type_mock.return_value = str(
+                expected_output_path
+            )
+            with caplog.at_level(
+                logging.INFO, logger='sciencebeam_parser.service.api.dependencies'
+            ):
+                response = test_client.post(self.get_api_path(), files={
+                    'input': (PDF_FILENAME_1, BytesIO(PDF_CONTENT_1))
+                })
+            assert response.status_code == 200
+            assert any(
+                PDF_FILENAME_1 in message for message in caplog.messages
+            ), caplog.messages
+
     class TestProcessHeaderDocument(_AbstractPdfConversionApiTest):
         def get_api_path(self) -> str:
             return '/processHeaderDocument'

--- a/tests/service/api/models_router_test.py
+++ b/tests/service/api/models_router_test.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from contextlib import contextmanager
+from typing import List, Tuple
 from unittest.mock import MagicMock
 
 from fastapi import FastAPI
@@ -13,7 +15,10 @@ from sciencebeam_trainer_delft.sequence_labelling.tag_formatter import (
 )
 
 from sciencebeam_parser.models.data import DEFAULT_APP_FEATURES_CONTEXT
-from sciencebeam_parser.service.api.routers.models import create_models_router
+from sciencebeam_parser.service.api.routers.models import (
+    ModelResponseRouterFactory,
+    create_models_router
+)
 from tests.processors.fulltext.model_mocks import MockFullTextModels
 
 
@@ -33,6 +38,51 @@ def _test_client(mock_fulltext_models: MockFullTextModels) -> TestClient:
     app = FastAPI()
     app.include_router(create_models_router(sciencebeam_parser_mock))
     return TestClient(app)
+
+
+class TestHandlePostSpan:
+    def test_should_name_the_document_and_the_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """This endpoint does not go through the parser's own document span.
+
+        It reads `source.source_path` directly, so without a span of its own the
+        model calls underneath it would belong to no document.
+        """
+        recorded: List[Tuple[str, dict]] = []
+
+        @contextmanager
+        def recording_span(name: str, attributes=None, **_kwargs):
+            recorded.append((name, dict(attributes or {})))
+            yield MagicMock(name='span')
+
+        monkeypatch.setattr(
+            'sciencebeam_parser.service.api.routers.models.span', recording_span
+        )
+        factory = ModelResponseRouterFactory(
+            name='citation',
+            model=MagicMock(name='model'),
+            pdfalto_wrapper=MagicMock(name='pdfalto_wrapper'),
+            app_features_context=DEFAULT_APP_FEATURES_CONTEXT,
+            model_name='citation'
+        )
+        monkeypatch.setattr(
+            factory, '_handle_post', lambda *args, **kwargs: 'the response'
+        )
+        source = MagicMock(name='source')
+        source.source_name = 'the-uploaded-name.pdf'
+        source.source_media_type = 'application/pdf'
+
+        assert factory.handle_post(source, 'json') == 'the response'
+        assert recorded == [(
+            'process_document',
+            {
+                'sciencebeam.document.name': 'the-uploaded-name.pdf',
+                'sciencebeam.document.source_media_type': 'application/pdf',
+                'sciencebeam.model.name': 'citation',
+                'sciencebeam.model.output_format': 'json',
+            }
+        )]
 
 
 class TestGetFeatureNames:

--- a/tests/utils/telemetry_test.py
+++ b/tests/utils/telemetry_test.py
@@ -1,0 +1,97 @@
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from sciencebeam_parser.utils.telemetry import (
+    get_configured_endpoint,
+    get_trace_id,
+    get_tracer,
+    is_configured,
+    span
+)
+
+
+class RecordingSpan:
+    def __init__(self):
+        self.attributes: List[Tuple[str, Any]] = []
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes.append((key, value))
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dict(self.attributes)
+
+
+@pytest.fixture(name='no_endpoint')
+def _no_endpoint(monkeypatch: pytest.MonkeyPatch):
+    for name in ('OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'):
+        monkeypatch.delenv(name, raising=False)
+
+
+class TestIsConfigured:
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_be_false_without_an_endpoint(self):
+        assert is_configured() is False
+
+    def test_should_be_true_with_an_otlp_endpoint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318')
+        assert is_configured() is True
+
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_ignore_a_backend_specific_endpoint_variable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv('PHOENIX_COLLECTOR_ENDPOINT', 'http://localhost:6006')
+        assert is_configured() is False
+
+
+class TestGetConfiguredEndpoint:
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_be_none_without_any_endpoint(self):
+        assert get_configured_endpoint() is None
+
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_prefer_the_traces_endpoint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://base:4318')
+        monkeypatch.setenv(
+            'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'http://traces:4318/v1/traces'
+        )
+        assert get_configured_endpoint() == 'http://traces:4318/v1/traces'
+
+
+class TestGetTracer:
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_be_none_without_an_endpoint(self):
+        assert get_tracer() is None
+
+
+class TestSpan:
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_be_a_no_op_without_an_endpoint(self):
+        with span('process_document', {'sciencebeam.document.name': 'a.pdf'}) as started:
+            started.set_attribute('anything', 1)
+        assert type(started).__name__ == 'NoOpSpan'
+
+
+class TestGetTraceId:
+    @pytest.mark.usefixtures('no_endpoint')
+    def test_should_be_none_for_the_no_op_span(self):
+        with span('process_document') as started:
+            assert get_trace_id(started) is None
+
+    def test_should_be_none_for_a_span_without_a_trace(self):
+        class SpanWithoutATrace:
+            def get_span_context(self):
+                return None
+
+        assert get_trace_id(SpanWithoutATrace()) is None  # type: ignore[arg-type]
+
+    def test_should_be_the_zero_padded_hex_of_the_trace_id(self):
+        class SpanContext:
+            trace_id = 0x0af7651916cd43dd8448eb211c80319c
+
+        class TracedSpan(RecordingSpan):
+            def get_span_context(self):
+                return SpanContext()
+
+        assert get_trace_id(TracedSpan()) == '0af7651916cd43dd8448eb211c80319c'


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/154

# Know which document a model call came from

Every call made while serving a request now nests under a `process_document`
span naming the document, and the log line for a completed call names its
trace id.

Today a traced run is a flat list of model calls belonging to nobody. Nothing
in the log or on a span names the document, so 60 documents are 60 anonymous
ones, and reading a run means guessing from log order — which is not sound
either, since the benchmark keeps more than one document in flight.

## What it makes possible

**A trace answers "which document?" on its own.** A model call sits under the
document it belongs to, so a slow document, an expensive one, or one where the
answers came back wrong is something you can open rather than infer. Cost and
token counts total per document instead of per call.

**The log and the trace are joinable.** They hold different halves of the same
call — the prompt and the response are on the span, the fields a call dropped
are in the log — and neither could reach the other. The trace id on the
completion log line closes that, so a warning about a dropped field leads to
the exact prompt that produced it.

**Concurrency stops being a reason to distrust the record.** Batches are sent
in parallel, and a worker thread does not inherit the current span, so batch
spans would otherwise each begin their own trace. They now nest correctly,
which means a run does not have to be serialised to be readable.

**Tracing is available to the rest of the parser.** It was written for the llm
engine and lived inside it; it is now `utils/telemetry.py`, and the engine
keeps only the GenAI and OpenInference semantics it adds on top.

## Known gap

The training data CLI names its source but runs models off the fulltext models
directly rather than through the session source, so it has no document span
yet.