### PR TITLE
Benchmark scaffolding for the trained JATS annotation model

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -256,15 +256,40 @@ jobs:
           if [ -f ${{ env.BENCHMARK_RUN }}/comparison.md ]; then
             REPORT=${{ env.BENCHMARK_RUN }}/comparison.md
           fi
-          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq '[.[] | select(.body | startswith("## ScienceBeam Parser Evaluation"))] | .[0].id // empty')
-          if [ -n "$COMMENT_ID" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID} \
-              -X PATCH -f body="$(cat ${REPORT})"
-          else
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body-file "${REPORT}"
-          fi
+          PR=${{ github.event.pull_request.number }}
+          LABEL="${{ steps.image_tag.outputs.value }} (${{ env.BENCHMARK_MODE }}, ${{ env.BENCHMARK_SPLIT }})"
+
+          # A new comment per run rather than an edit, because an edit sends no
+          # notification -- a finished run looked like one that never triggered.
+          # Older reports are collapsed rather than deleted, so a PR with several
+          # runs stays readable and every run's numbers remain there to compare.
+          #
+          # The marker is what finds them again, and carries the label so a
+          # collapsed summary can still say which run it was.
+          gh api "repos/${{ github.repository }}/issues/${PR}/comments" --paginate \
+            --jq '.[] | select(.body | startswith("<!-- benchmark-report:"))
+                      | select(.body | contains("<summary><b>Benchmark") | not) | .id' \
+          | while read -r id; do
+              gh api "repos/${{ github.repository }}/issues/comments/${id}" --jq .body > old.md
+              OLD_LABEL=$(head -1 old.md | sed -e 's/^<!-- benchmark-report: //' -e 's/ -->$//')
+              {
+                head -1 old.md
+                echo "<details>"
+                echo "<summary><b>Benchmark</b> — ${OLD_LABEL}</summary>"
+                echo ""
+                tail -n +2 old.md
+                echo ""
+                echo "</details>"
+              } > collapsed.md
+              gh api "repos/${{ github.repository }}/issues/comments/${id}" \
+                -X PATCH -f body="$(cat collapsed.md)"
+            done
+
+          {
+            echo "<!-- benchmark-report: ${LABEL} -->"
+            cat "${REPORT}"
+          } > benchmark-comment.md
+          gh pr comment "${PR}" --body-file benchmark-comment.md
 
       - name: Upload run artifacts
         if: always()

--- a/.github/workflows/generate-llm-predictions.yml
+++ b/.github/workflows/generate-llm-predictions.yml
@@ -14,8 +14,9 @@ on:
         default: 'https://elifepathways--jats-orchestrator-web.modal.run'
         type: string
       checkpoint:
-        description: 'Checkpoint id; becomes the version the predictions are stored under'
-        required: true
+        description: 'Checkpoint id; blank uses the version eval.yml names for this tool'
+        required: false
+        default: ''
         type: string
       mode:
         description: 'Samples nest, so the largest mode covers every smaller one'
@@ -70,14 +71,18 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
+          CHECKPOINT_ARG=""
+          if [ -n "${{ inputs.checkpoint }}" ]; then
+            CHECKPOINT_ARG="--checkpoint ${{ inputs.checkpoint }}"
+          fi
           uv run python -m benchmarks.predict_llm \
             --config benchmarks/eval.yml \
             --mode "${{ inputs.mode }}" \
             --split "${{ inputs.split }}" \
             --data benchmarks/data \
-            --out "benchmarks/runs/llm-${{ inputs.checkpoint }}" \
+            --out benchmarks/runs/llm \
             --endpoint "${{ inputs.endpoint }}" \
-            --checkpoint "${{ inputs.checkpoint }}" \
+            ${CHECKPOINT_ARG} \
             --concurrency "${{ inputs.concurrency }}" \
             --push-to sciencebeam-eval-predictions
 
@@ -86,11 +91,11 @@ jobs:
       - name: Summarise
         if: always()
         run: |
-          MANIFEST="benchmarks/runs/llm-${{ inputs.checkpoint }}/predictions/manifest.jsonl"
+          MANIFEST="benchmarks/runs/llm/predictions/manifest.jsonl"
           {
             echo "### LLM prediction run"
             echo ""
-            echo "- checkpoint: \`${{ inputs.checkpoint }}\`"
+            echo "- checkpoint: \`$(grep -A2 'tool: jats-agentic-annotation' benchmarks/eval.yml | grep version: | awk '{print $2}')\`"
             echo "- ${{ inputs.split }} / ${{ inputs.mode }}"
             if [ -f "$MANIFEST" ]; then
               echo "- ok: $(grep -c '"status": "ok"' "$MANIFEST" || echo 0)"
@@ -104,6 +109,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: llm-predictions-${{ inputs.checkpoint }}
-          path: benchmarks/runs/llm-${{ inputs.checkpoint }}/
+          name: llm-predictions
+          path: benchmarks/runs/llm/
           retention-days: 30

--- a/.github/workflows/generate-llm-predictions.yml
+++ b/.github/workflows/generate-llm-predictions.yml
@@ -1,0 +1,109 @@
+# Annotates the benchmark corpora with the trained JATS model and stores the
+# result. Separate from benchmark.yml because it is slow -- minutes per document
+# -- and because it is the only job that sends manuscripts to the model.
+#
+# No GPU: the model is served over HTTP, so a standard runner is enough.
+name: Generate LLM predictions
+
+on:
+  workflow_dispatch:
+    inputs:
+      endpoint:
+        description: 'Annotation service base URL'
+        required: true
+        default: 'https://elifepathways--jats-orchestrator-web.modal.run'
+        type: string
+      checkpoint:
+        description: 'Checkpoint id; becomes the version the predictions are stored under'
+        required: true
+        type: string
+      mode:
+        description: 'Samples nest, so the largest mode covers every smaller one'
+        required: false
+        default: 'smoke'
+        type: choice
+        options: [smoke, small, medium, large, full]
+      split:
+        description: 'validation is what PR benchmark runs read'
+        required: false
+        default: 'validation'
+        type: choice
+        options: [validation, train, test]
+      concurrency:
+        description: 'Documents in flight; each holds 3 calls open'
+        required: false
+        default: '2'
+        type: string
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    # Well beyond benchmark.yml's 120, since 60 documents at minutes each will
+    # not fit in it. Six hours is the GitHub maximum.
+    timeout-minutes: 360
+    environment: benchmark
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps
+        run: uv sync --frozen --group benchmark
+
+      - name: Checkout predictions repo
+        uses: actions/checkout@v5
+        with:
+          repository: elifepathways/sciencebeam-eval-predictions
+          path: sciencebeam-eval-predictions
+          token: ${{ secrets.PREDICTIONS_REPO_PAT }}
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: .gitignore
+          sparse-checkout-cone-mode: false
+
+      - name: Annotate and store
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          uv run python -m benchmarks.predict_llm \
+            --config benchmarks/eval.yml \
+            --mode "${{ inputs.mode }}" \
+            --split "${{ inputs.split }}" \
+            --data benchmarks/data \
+            --out "benchmarks/runs/llm-${{ inputs.checkpoint }}" \
+            --endpoint "${{ inputs.endpoint }}" \
+            --checkpoint "${{ inputs.checkpoint }}" \
+            --concurrency "${{ inputs.concurrency }}" \
+            --push-to sciencebeam-eval-predictions
+
+      # A document that failed is recorded rather than raised, so the run can
+      # succeed having annotated nothing. The manifest is what says otherwise.
+      - name: Summarise
+        if: always()
+        run: |
+          MANIFEST="benchmarks/runs/llm-${{ inputs.checkpoint }}/predictions/manifest.jsonl"
+          {
+            echo "### LLM prediction run"
+            echo ""
+            echo "- checkpoint: \`${{ inputs.checkpoint }}\`"
+            echo "- ${{ inputs.split }} / ${{ inputs.mode }}"
+            if [ -f "$MANIFEST" ]; then
+              echo "- ok: $(grep -c '"status": "ok"' "$MANIFEST" || echo 0)"
+              echo "- errors: $(grep -c '"status": "error"' "$MANIFEST" || echo 0)"
+            else
+              echo "- no manifest written"
+            fi
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: llm-predictions-${{ inputs.checkpoint }}
+          path: benchmarks/runs/llm-${{ inputs.checkpoint }}/
+          retention-days: 30

--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -221,3 +221,10 @@ baselines:
     version: main
     profile: grobid_crf
     generate: false
+  # Read but never run: annotating needs a GPU the runner lacks, so predictions
+  # are generated separately (benchmarks.predict_llm) and pushed to the store.
+  # `version` is the checkpoint, and must match what generation used.
+  - tool: jats-agentic-annotation
+    version: qwen3.5-9b-rl-v13e-s50
+    profile: default
+    generate: false

--- a/benchmarks/eval.yml
+++ b/benchmarks/eval.yml
@@ -225,6 +225,6 @@ baselines:
   # are generated separately (benchmarks.predict_llm) and pushed to the store.
   # `version` is the checkpoint, and must match what generation used.
   - tool: jats-agentic-annotation
-    version: qwen3.5-9b-rl-v13e-s50
+    version: qwen3.5-9b-teacher-distill-v1
     profile: default
     generate: false

--- a/benchmarks/fetch.py
+++ b/benchmarks/fetch.py
@@ -323,3 +323,23 @@ def fetch_training_source(
     filtered_cfg = {**cfg, "sampling": filtered_sampling}
     in_split = allowed.intersection(cfg["dataset"]["splits"].get(split, {}))
     return fetch_data(filtered_cfg, mode, split, data_dir, include=in_split)
+
+
+def get_corpus_variants(
+    config: dict, split: str, include: Optional[Iterable[str]] = None
+) -> dict:
+    """Each covered corpus's prediction variant.
+
+    Limited to the corpora the run covers, so predictions for a corpus that was not
+    run are neither looked for nor stored. A versioned corpus names its version here,
+    which is what keeps predictions against two versions of it apart.
+    """
+    split_cfg = config["dataset"]["splits"].get(split, {})
+    result = {}
+    for corpus in included_corpora(config, split, include):
+        corpus_cfg = split_cfg[corpus]
+        if isinstance(corpus_cfg, dict):
+            result[corpus] = corpus_cfg.get("variant", "v1")
+        else:
+            result[corpus] = "v1"
+    return result

--- a/benchmarks/predict_llm.py
+++ b/benchmarks/predict_llm.py
@@ -1,0 +1,325 @@
+"""Predict with the trained JATS annotation model.
+
+The model never sees the PDF: the service converts it to markdown, then
+annotates it in three rollouts -- front, body, back -- each returning a complete
+`<article>` with only its own section filled in. A prediction is those merged.
+
+Generation is separate from the benchmark run, which has no GPU: predictions are
+pushed to the store and read back like any baseline that does not generate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import httpx
+import yaml
+from lxml import etree
+
+from benchmarks.fetch import fetch_data, resolved_sources
+from benchmarks.predict import _append_manifest, _load_done, _Progress
+
+LOGGER = logging.getLogger(__name__)
+
+# JATS document order, which is also merge order.
+SECTIONS: Tuple[str, ...] = ("front", "body", "back")
+
+PREPROCESS_PATH = "/preprocess"
+ANNOTATE_PATH = "/annotate"
+
+# One section of a five-line document took 232s, so this is not the parser's scale.
+DEFAULT_TIMEOUT_SECONDS = 1800
+# Documents in flight. Each one holds three calls open, so this multiplies.
+DEFAULT_CONCURRENCY = 2
+
+# Not redistributable, and generation is the step that uploads them.
+RESTRICTED_CORPORA_FOR_LLM = frozenset({"plos-manuscripts"})
+
+
+def check_restricted_corpora(include: Optional[Iterable[str]]) -> None:
+    restricted = sorted(RESTRICTED_CORPORA_FOR_LLM.intersection(include or ()))
+    if restricted:
+        raise SystemExit(
+            f"refusing to annotate {', '.join(restricted)} with a served model:"
+            " those manuscripts are not redistributable. Drop the corpus or point"
+            " --endpoint at a self-hosted service."
+        )
+
+
+def _resolve_concurrency(concurrency: int) -> int:
+    """0 means this module's default, not the parser's cpu-count one.
+
+    A document is one call there and three here, against a service whose
+    throughput is the bound -- local cores are the wrong thing to scale with.
+    """
+    return concurrency if concurrency > 0 else DEFAULT_CONCURRENCY
+
+
+def _find_section(root: etree._Element, section: str) -> Optional[etree._Element]:
+    """The named section of an article, whatever namespace it is declared in."""
+    matches = root.xpath(f"*[local-name()='{section}']")
+    return matches[0] if matches else None
+
+
+def merge_section_documents(xml_by_section: Dict[str, str]) -> bytes:
+    """One article from the three single-section documents the model returns.
+
+    Every response carries a full skeleton, so merging replaces each section with
+    the one from the response that annotated it. The front response is preferred
+    as the skeleton: `article-type` and `xml:lang` come from the front matter.
+    """
+    present = [section for section in SECTIONS if xml_by_section.get(section)]
+    if not present:
+        raise ValueError("no section responses to merge")
+
+    skeleton_source = xml_by_section.get("front") or xml_by_section[present[0]]
+    merged = etree.fromstring(skeleton_source.encode("utf-8"))
+
+    for section in SECTIONS:
+        source = xml_by_section.get(section)
+        if not source:
+            continue
+        annotated = _find_section(etree.fromstring(source.encode("utf-8")), section)
+        if annotated is None:
+            continue
+        existing = _find_section(merged, section)
+        if existing is not None:
+            merged.replace(existing, annotated)
+        else:
+            merged.append(annotated)
+
+    return etree.tostring(merged, xml_declaration=True, encoding="utf-8")
+
+
+async def _preprocess(
+    client: httpx.AsyncClient, endpoint: str, pdf_path: Path, timeout: int
+) -> Dict[str, Any]:
+    response = await client.post(
+        f"{endpoint}{PREPROCESS_PATH}",
+        files={"file": (pdf_path.name, pdf_path.read_bytes(), "application/pdf")},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    result = response.json()
+    if not result.get("markdown"):
+        raise RuntimeError(f"preprocess returned no markdown for {pdf_path.name}")
+    return result
+
+
+async def _annotate(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    section: str,
+    preprocessed: Dict[str, Any],
+    timeout: int,
+) -> str:
+    data = {
+        "markdown": preprocessed["markdown"],
+        "section": section,
+        "doc_id": preprocessed.get("doc_id", ""),
+    }
+    # The inline/xref merge, which only the body rollout consumes.
+    candidates = preprocessed.get("candidates")
+    if section == "body" and candidates:
+        data["candidates"] = json.dumps(candidates)
+
+    response = await client.post(f"{endpoint}{ANNOTATE_PATH}", data=data, timeout=timeout)
+    response.raise_for_status()
+    payload = response.json()
+    xml = payload.get("xml")
+    if not xml:
+        raise RuntimeError(f"annotate returned no xml for section {section!r}")
+    return xml
+
+
+async def _predict_one(
+    client: httpx.AsyncClient, endpoint: str, pdf_path: Path, timeout: int
+) -> bytes:
+    """One document's JATS, or an exception.
+
+    A failed section fails the document: a partial article scores as one whose
+    references were not there, which a service error and a real result share.
+    """
+    preprocessed = await _preprocess(client, endpoint, pdf_path, timeout)
+    rollouts = await asyncio.gather(
+        *[_annotate(client, endpoint, section, preprocessed, timeout) for section in SECTIONS]
+    )
+    return merge_section_documents(dict(zip(SECTIONS, rollouts)))
+
+
+async def _run_predict_async(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    records: List[Dict[str, Any]],
+    done: set,
+    run_dir: Path,
+    endpoint: str,
+    timeout: int,
+    concurrency: int,
+) -> Tuple[int, int]:
+    to_process = [r for r in records if (r["corpus"], r["record_id"]) not in done]
+    skipped = len(records) - len(to_process)
+    if skipped:
+        LOGGER.info("Skipping %d already-cached documents", skipped)
+    LOGGER.info(
+        "Annotating %d documents (concurrency=%d, %d calls in flight)",
+        len(to_process), concurrency, concurrency * len(SECTIONS),
+    )
+
+    progress = _Progress(len(to_process))
+    sem = asyncio.Semaphore(concurrency)
+
+    async with httpx.AsyncClient() as client:
+
+        async def _process_one(rec: Dict[str, Any]) -> None:
+            corpus = rec["corpus"]
+            record_id = rec["record_id"]
+            out_path = run_dir / "predictions" / corpus / f"{record_id}.jats.xml"
+            async with sem:
+                t0 = time.monotonic()
+                try:
+                    merged = await _predict_one(
+                        client, endpoint, Path(rec["pdf_path"]), timeout
+                    )
+                    elapsed_ms = round((time.monotonic() - t0) * 1000)
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    out_path.write_bytes(merged)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "ok", "elapsed_ms": elapsed_ms,
+                    })
+                    progress.record_ok(corpus, record_id, elapsed_ms)
+                except httpx.HTTPStatusError as exc:
+                    msg = str(exc)
+                    body = exc.response.text[:2000] if exc.response.text else ""
+                    if body:
+                        LOGGER.error("err %s/%s  %s\n%s", corpus, record_id, msg, body)
+                    else:
+                        LOGGER.error("err %s/%s  %s", corpus, record_id, msg)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "error", "error": msg, "error_body": body,
+                    })
+                    progress.record_err(corpus, record_id)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    msg = str(exc)
+                    _append_manifest(run_dir, {
+                        "corpus": corpus, "record_id": record_id,
+                        "status": "error", "error": msg,
+                    })
+                    progress.record_err(corpus, record_id)
+                    LOGGER.error("err %s/%s  %s", corpus, record_id, msg)
+
+        await asyncio.gather(*[_process_one(rec) for rec in to_process])
+
+    return progress.n_ok, progress.n_err
+
+
+def run_predict_llm(  # noqa: E501  pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    config: dict,
+    mode: str,
+    split: str,
+    data_dir: Path,
+    run_dir: Path,
+    endpoint: str,
+    checkpoint: str,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    include: Optional[Iterable[str]] = None,
+) -> None:
+    check_restricted_corpora(include)
+    records = fetch_data(config, mode, split, data_dir, include=include)
+    sources = resolved_sources(config, split, include)
+    done = _load_done(run_dir)
+
+    t_start = time.monotonic()
+    n_ok, n_err = asyncio.run(
+        _run_predict_async(
+            records, done, run_dir, endpoint.rstrip("/"), timeout,
+            _resolve_concurrency(concurrency),
+        )
+    )
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(json.dumps({
+        # `parser_image` is the key the report renders; here that is the checkpoint.
+        "parser_image": checkpoint,
+        "profile": "default",
+        "endpoint": endpoint,
+        "checkpoint": checkpoint,
+        "sources": sources,
+        "split": split,
+        "mode": mode,
+        "corpora": list(sources),
+        "fields": config["fields"],
+        "n_records": n_ok,
+        "n_errors": n_err,
+        "elapsed_s": round(time.monotonic() - t_start, 1),
+    }, indent=2))
+
+    LOGGER.info(
+        "done  ok=%d  err=%d  elapsed=%.1fs",
+        n_ok, n_err, time.monotonic() - t_start,
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Predict: annotate each PDF with the trained JATS model and save JATS XML"
+    )
+    parser.add_argument("--config", default="benchmarks/eval.yml")
+    parser.add_argument("--mode", default="smoke")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--data", default="benchmarks/data", help="Data cache directory")
+    parser.add_argument("--out", required=True, help="Run output dir")
+    parser.add_argument(
+        "--endpoint", required=True,
+        help=(
+            "Base URL of the annotation service. Required rather than defaulted:"
+            " every document of the run is uploaded to it"
+        ),
+    )
+    parser.add_argument(
+        "--checkpoint", required=True,
+        help="Checkpoint identifier, recorded with the run and used as its store version",
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=DEFAULT_CONCURRENCY,
+        help=f"Documents in flight, each holding {len(SECTIONS)} calls open"
+             f" (default {DEFAULT_CONCURRENCY})",
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Per-call timeout in seconds (default {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument(
+        "--include-corpus", action="append", default=None, dest="include_corpus",
+        metavar="CORPUS", help="Also run an opt-in corpus, repeatable",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    with open(args.config, encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    run_predict_llm(
+        config=config,
+        mode=args.mode,
+        split=args.split,
+        data_dir=Path(args.data),
+        run_dir=Path(args.out),
+        endpoint=args.endpoint,
+        checkpoint=args.checkpoint,
+        concurrency=args.concurrency,
+        timeout=args.timeout,
+        include=args.include_corpus,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/predict_llm.py
+++ b/benchmarks/predict_llm.py
@@ -283,6 +283,18 @@ def run_predict_llm(  # noqa: E501  pylint: disable=too-many-arguments,too-many-
         LOGGER.info("Pushed %d prediction(s) to %s", n_ok, push_to)
 
 
+def checkpoint_from_config(config: dict) -> Optional[str]:
+    """The checkpoint the eval config already names for this tool.
+
+    One source of truth: generation stores under the version the benchmark reads,
+    so the two cannot be pointed at different paths by a typo.
+    """
+    for baseline in config.get("baselines", []):
+        if isinstance(baseline, dict) and baseline.get("tool") == TOOL_NAME:
+            return baseline.get("version")
+    return None
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(
         description="Predict: annotate each PDF with the trained JATS model and save JATS XML"
@@ -300,8 +312,11 @@ def main(argv: Optional[List[str]] = None) -> None:
         ),
     )
     parser.add_argument(
-        "--checkpoint", required=True,
-        help="Checkpoint identifier, recorded with the run and used as its store version",
+        "--checkpoint", default=None,
+        help=(
+            "Checkpoint identifier, recorded with the run and used as its store"
+            " version. Defaults to the version the eval config gives this tool"
+        ),
     )
     parser.add_argument(
         "--concurrency", type=int, default=DEFAULT_CONCURRENCY,
@@ -327,6 +342,13 @@ def main(argv: Optional[List[str]] = None) -> None:
     with open(args.config, encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
+    checkpoint = args.checkpoint or checkpoint_from_config(config)
+    if not checkpoint:
+        raise SystemExit(
+            f"no --checkpoint given and {args.config} names no version for "
+            f"{TOOL_NAME!r}; predictions would have nowhere to be stored"
+        )
+
     run_predict_llm(
         config=config,
         mode=args.mode,
@@ -334,7 +356,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         data_dir=Path(args.data),
         run_dir=Path(args.out),
         endpoint=args.endpoint,
-        checkpoint=args.checkpoint,
+        checkpoint=checkpoint,
         concurrency=args.concurrency,
         timeout=args.timeout,
         include=args.include_corpus,

--- a/benchmarks/predict_llm.py
+++ b/benchmarks/predict_llm.py
@@ -22,13 +22,18 @@ import httpx
 import yaml
 from lxml import etree
 
-from benchmarks.fetch import fetch_data, resolved_sources
+from benchmarks.fetch import fetch_data, get_corpus_variants, resolved_sources
+from benchmarks.predictions_store import RepoPredictionsStore
 from benchmarks.predict import _append_manifest, _load_done, _Progress
 
 LOGGER = logging.getLogger(__name__)
 
 # JATS document order, which is also merge order.
 SECTIONS: Tuple[str, ...] = ("front", "body", "back")
+
+# Must match the `tool:` of the eval.yml baseline, which is how the store path
+# is built on both sides.
+TOOL_NAME = "jats-agentic-annotation"
 
 PREPROCESS_PATH = "/preprocess"
 ANNOTATE_PATH = "/annotate"
@@ -230,6 +235,7 @@ def run_predict_llm(  # noqa: E501  pylint: disable=too-many-arguments,too-many-
     concurrency: int = DEFAULT_CONCURRENCY,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
     include: Optional[Iterable[str]] = None,
+    push_to: Optional[Path] = None,
 ) -> None:
     check_restricted_corpora(include)
     records = fetch_data(config, mode, split, data_dir, include=include)
@@ -266,6 +272,16 @@ def run_predict_llm(  # noqa: E501  pylint: disable=too-many-arguments,too-many-
         n_ok, n_err, time.monotonic() - t_start,
     )
 
+    if push_to:
+        store = RepoPredictionsStore(push_to)
+        store.push(
+            TOOL_NAME, checkpoint, "default", split, run_dir,
+            get_corpus_variants(config, split, include),
+            {"tool": TOOL_NAME, "version": checkpoint, "profile": "default",
+             "split": split, "mode": mode, "endpoint": endpoint},
+        )
+        LOGGER.info("Pushed %d prediction(s) to %s", n_ok, push_to)
+
 
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(
@@ -300,6 +316,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--include-corpus", action="append", default=None, dest="include_corpus",
         metavar="CORPUS", help="Also run an opt-in corpus, repeatable",
     )
+    parser.add_argument(
+        "--push-to", default=None, metavar="REPO",
+        help="Checked-out predictions repo to commit and push the results to",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -318,6 +338,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         concurrency=args.concurrency,
         timeout=args.timeout,
         include=args.include_corpus,
+        push_to=Path(args.push_to) if args.push_to else None,
     )
 
 

--- a/benchmarks/prediction_files.py
+++ b/benchmarks/prediction_files.py
@@ -1,0 +1,53 @@
+"""What a prediction file is called, and how to find one.
+
+The extension says which schema it holds: `.tei.xml` from the GROBID-compatible
+tools, `.jats.xml` from an annotation model. Both score through the same field
+definitions, since sciencebeam-judge picks its mapping from the root element.
+
+One definition, so the store and the scorer cannot disagree about what a
+prediction is -- they did, silently, while the store looked only for TEI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+# Longest-first, so that stripping a suffix cannot leave part of another behind.
+PREDICTION_SUFFIXES: Tuple[str, ...] = (".jats.xml", ".tei.xml")
+
+
+def is_prediction_file(name: str) -> bool:
+    return any(name.endswith(suffix) for suffix in PREDICTION_SUFFIXES)
+
+
+def record_id_from_name(name: str) -> str:
+    """The record id a prediction file is named for.
+
+    Removes the suffix rather than using `Path.stem`, which leaves the inner
+    extension behind, or replacing '.tei', which rewrites ids containing it.
+    """
+    for suffix in PREDICTION_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def record_id_from_path(path: Path) -> str:
+    return record_id_from_name(path.name)
+
+
+def iter_prediction_files(directory: Path) -> Iterator[Path]:
+    """Every prediction in a directory, ordered by record id.
+
+    By id rather than filename, so mixed schemas still traverse in a stable order.
+    """
+    if not directory.is_dir():
+        return iter(())
+    found = [path for path in directory.iterdir() if is_prediction_file(path.name)]
+    return iter(sorted(found, key=record_id_from_path))
+
+
+def iter_prediction_names(names: Iterable[str]) -> Iterator[str]:
+    """The prediction files among a listing of bare names."""
+    return (name for name in names if is_prediction_file(name))

--- a/benchmarks/predictions_store.py
+++ b/benchmarks/predictions_store.py
@@ -9,6 +9,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from benchmarks.prediction_files import (
+    is_prediction_file,
+    iter_prediction_files,
+    record_id_from_name,
+)
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -115,7 +121,6 @@ class RepoPredictionsStore:
 
     def _stored_ids(self, prefix: str, split: str, corpus_variants: dict) -> set:
         """(corpus, record_id) for every prediction filed under these variants."""
-        suffix = ".tei.xml"
         stored = set()
         for corpus, variant in corpus_variants.items():
             listing = self._git(
@@ -126,8 +131,8 @@ class RepoPredictionsStore:
                 continue
             for line in listing.stdout.splitlines():
                 name = line.strip().rsplit("/", 1)[-1]
-                if name.endswith(suffix):
-                    stored.add((corpus, name[: -len(suffix)]))
+                if is_prediction_file(name):
+                    stored.add((corpus, record_id_from_name(name)))
         return stored
 
     def fetch(
@@ -143,7 +148,7 @@ class RepoPredictionsStore:
                 continue
             dest = local_dir / "predictions" / corpus
             dest.mkdir(parents=True, exist_ok=True)
-            for f in src.glob("*.tei.xml"):
+            for f in iter_prediction_files(src):
                 shutil.copy2(f, dest / f.name)
         manifest_src = self.repo_dir / prefix / split / "manifest.jsonl"
         if manifest_src.exists():
@@ -160,7 +165,7 @@ class RepoPredictionsStore:
                 continue
             dest_corpus = dest_base / corpus / variant / split
             dest_corpus.mkdir(parents=True, exist_ok=True)
-            for f in src_corpus.glob("*.tei.xml"):
+            for f in iter_prediction_files(src_corpus):
                 shutil.copy2(f, dest_corpus / f.name)
         manifest_src = local_dir / "predictions" / "manifest.jsonl"
         if manifest_src.exists():

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -12,6 +12,7 @@ import yaml
 
 from benchmarks.fetch import fetch_gold, included_corpora
 from benchmarks.predict import run_predict
+from benchmarks.predict_llm import RESTRICTED_CORPORA_FOR_LLM, run_predict_llm
 from benchmarks.predictions_store import LocalPredictionsStore, RepoPredictionsStore
 from benchmarks.report import run_compare
 from benchmarks.score import run_score
@@ -122,7 +123,14 @@ def _generate_predictions(  # pylint: disable=too-many-arguments,too-many-positi
     config: dict, mode: str, split: str, data_dir: Path, run_dir: Path,
     tool: str, version: str, profile: str, concurrency: int,
     include: Optional[Iterable[str]] = None,
+    endpoint: Optional[str] = None,
 ) -> None:
+    # A served model has no container to start, and its version is the checkpoint.
+    if endpoint:
+        run_predict_llm(config, mode, split, data_dir, run_dir,
+                        endpoint, version, concurrency, include=include)
+        return
+
     dcfg = _tool_docker_config(tool, version)
     container = f"benchmark-baseline-{tool}"
     _docker_stop(container)
@@ -151,6 +159,7 @@ def _run_baseline(  # pylint: disable=too-many-locals
     store: PredictionsStore,
     concurrency: int,
     include: Optional[Iterable[str]] = None,
+    endpoint: Optional[str] = None,
 ) -> Optional[Tuple[str, Path]]:
     run_dir = runs_dir / "baselines" / tool / version / profile / split
     done_ids = store.get_done_ids(tool, version, profile, split, corpus_variants)
@@ -211,7 +220,8 @@ def _run_baseline(  # pylint: disable=too-many-locals
 
     if missing:
         _generate_predictions(config, mode, split, data_dir, run_dir,
-                              tool, version, profile, concurrency, include=include)
+                              tool, version, profile, concurrency, include=include,
+                              endpoint=endpoint)
         store.push(tool, version, profile, split, run_dir, corpus_variants, {
             "tool": tool, "version": version, "profile": profile,
             "split": split, "mode": mode,
@@ -255,6 +265,7 @@ def run_benchmark(  # pylint: disable=too-many-arguments,too-many-positional-arg
             baseline["tool"], baseline["version"], profile,
             baseline.get("generate", True),
             expected_ids, corpus_variants, store, concurrency, include,
+            baseline.get("endpoint"),
         )
         if entry:
             labeled_paths.append(entry)
@@ -292,10 +303,8 @@ def run_benchmark(  # pylint: disable=too-many-arguments,too-many-positional-arg
         LOGGER.info("Only one summary available; skipping comparison report")
 
 
-# Corpora that must not be sent to a third-party model. Provider zero-retention
-# does not cover the intermediary, and these manuscripts are not redistributable,
-# so an LLM profile and one of these together is refused rather than warned about.
-RESTRICTED_CORPORA_FOR_LLM = frozenset({"plos-manuscripts"})
+# The restricted set lives with the code that sends documents; see
+# `benchmarks.predict_llm`.
 
 
 def check_llm_profile_corpora(

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -10,7 +10,7 @@ from typing import Iterable, List, Optional, Sequence, Tuple, Union
 import httpx
 import yaml
 
-from benchmarks.fetch import fetch_gold, included_corpora
+from benchmarks.fetch import fetch_gold, get_corpus_variants
 from benchmarks.predict import run_predict
 from benchmarks.predict_llm import RESTRICTED_CORPORA_FOR_LLM, run_predict_llm
 from benchmarks.predictions_store import LocalPredictionsStore, RepoPredictionsStore
@@ -75,26 +75,6 @@ def _baseline_env_vars(tool: str, profile: Optional[str]) -> dict:
     if profile and profile != "default":
         env["SCIENCEBEAM_PARSER__PROFILE"] = profile
     return env
-
-
-def _get_corpus_variants(
-    config: dict, split: str, include: Optional[Iterable[str]] = None
-) -> dict:
-    """Each covered corpus's prediction variant.
-
-    Limited to the corpora the run covers, so predictions for a corpus that was not
-    run are neither looked for nor stored. A versioned corpus names its version here,
-    which is what keeps predictions against two versions of it apart.
-    """
-    split_cfg = config["dataset"]["splits"].get(split, {})
-    result = {}
-    for corpus in included_corpora(config, split, include):
-        corpus_cfg = split_cfg[corpus]
-        if isinstance(corpus_cfg, dict):
-            result[corpus] = corpus_cfg.get("variant", "v1")
-        else:
-            result[corpus] = "v1"
-    return result
 
 
 def _coverage(expected_ids: set, done_ids: set) -> dict:
@@ -251,7 +231,7 @@ def run_benchmark(  # pylint: disable=too-many-arguments,too-many-positional-arg
     include: Optional[Iterable[str]] = None,
 ) -> None:
     # pylint: disable=too-many-locals
-    corpus_variants = _get_corpus_variants(config, split, include)
+    corpus_variants = get_corpus_variants(config, split, include)
     expected_ids = {
         (r["corpus"], r["record_id"])
         for r in fetch_gold(config, mode, split, data_dir, include=include)

--- a/benchmarks/score.py
+++ b/benchmarks/score.py
@@ -19,6 +19,7 @@ from sciencebeam_judge.parsing.xpath.xpath_functions import register_functions
 from sciencebeam_judge.resources import DEFAULT_XML_MAPPING_PATH
 
 from benchmarks.fetch import included_corpora
+from benchmarks.prediction_files import iter_prediction_files, record_id_from_path
 
 LOGGER = logging.getLogger(__name__)
 
@@ -109,8 +110,8 @@ def _score_corpus(  # pylint: disable=too-many-locals
     all_doc_scores: List[dict] = []
     n = 0
 
-    for pred_path in sorted(pred_dir.glob("*.tei.xml")):
-        record_id = pred_path.stem.replace(".tei", "")
+    for pred_path in iter_prediction_files(pred_dir):
+        record_id = record_id_from_path(pred_path)
         gold_path = data_dir / corpus / f"{record_id}.jats.xml"
 
         if not gold_path.exists():

--- a/benchmarks/tests/predict_llm_test.py
+++ b/benchmarks/tests/predict_llm_test.py
@@ -1,0 +1,81 @@
+import pytest
+
+from lxml import etree
+
+from benchmarks.predict_llm import (
+    check_restricted_corpora,
+    merge_section_documents,
+)
+
+
+def _article(front='', body='', back='', attrs=''):
+    return (
+        f'<article xmlns:xlink="http://www.w3.org/1999/xlink"{attrs}>'
+        f'<front>{front}</front><body>{body}</body><back>{back}</back>'
+        f'</article>'
+    )
+
+
+class TestMergeSectionDocuments:
+    def test_should_take_each_section_from_its_own_response(self):
+        merged = etree.fromstring(merge_section_documents({
+            'front': _article(front='<article-title>T</article-title>'),
+            'body': _article(body='<sec><title>S</title></sec>'),
+            'back': _article(back='<ref-list><ref/></ref-list>'),
+        }))
+        assert merged.find('front/article-title').text == 'T'
+        assert merged.find('body/sec/title').text == 'S'
+        assert merged.find('back/ref-list') is not None
+
+    def test_should_not_keep_the_empty_sections_of_the_skeleton(self):
+        # Appending rather than replacing would leave two of each, and score
+        # the empty one.
+        merged = etree.fromstring(merge_section_documents({
+            'front': _article(front='<article-title>T</article-title>'),
+            'body': _article(body='<sec><title>S</title></sec>'),
+            'back': _article(back='<ref-list><ref/></ref-list>'),
+        }))
+        assert len(merged.findall('front')) == 1
+        assert len(merged.findall('body')) == 1
+        assert len(merged.findall('back')) == 1
+
+    def test_should_keep_the_article_attributes_of_the_front_response(self):
+        merged = etree.fromstring(merge_section_documents({
+            'front': _article(attrs=' article-type="research-article"'),
+            'body': _article(),
+        }))
+        assert merged.get('article-type') == 'research-article'
+
+    def test_should_order_sections_as_jats_requires(self):
+        merged = etree.fromstring(merge_section_documents({
+            'back': _article(back='<ref-list/>'),
+            'body': _article(body='<sec/>'),
+        }))
+        assert [child.tag for child in merged] == ['front', 'body', 'back']
+
+    def test_should_merge_what_is_present_when_a_section_is_absent(self):
+        merged = etree.fromstring(merge_section_documents({
+            'body': _article(body='<sec><title>S</title></sec>'),
+        }))
+        assert merged.find('body/sec/title').text == 'S'
+
+    def test_should_reject_an_empty_set_of_responses(self):
+        with pytest.raises(ValueError):
+            merge_section_documents({})
+
+    def test_should_produce_an_article_rooted_document(self):
+        # The scorer picks its mapping from the root element.
+        merged = etree.fromstring(merge_section_documents({'front': _article()}))
+        assert merged.tag == 'article'
+
+
+class TestCheckRestrictedCorpora:
+    def test_should_allow_the_public_corpora(self):
+        check_restricted_corpora(['biorxiv', 'pkp'])
+
+    def test_should_allow_no_opt_in_corpora(self):
+        check_restricted_corpora(None)
+
+    def test_should_refuse_the_private_manuscripts(self):
+        with pytest.raises(SystemExit, match='not redistributable'):
+            check_restricted_corpora(['biorxiv', 'plos-manuscripts'])

--- a/benchmarks/tests/predict_llm_test.py
+++ b/benchmarks/tests/predict_llm_test.py
@@ -1,9 +1,11 @@
 import pytest
+import yaml
 
 from lxml import etree
 
 from benchmarks.predict_llm import (
     check_restricted_corpora,
+    checkpoint_from_config,
     merge_section_documents,
 )
 
@@ -79,3 +81,27 @@ class TestCheckRestrictedCorpora:
     def test_should_refuse_the_private_manuscripts(self):
         with pytest.raises(SystemExit, match='not redistributable'):
             check_restricted_corpora(['biorxiv', 'plos-manuscripts'])
+
+
+class TestCheckpointFromConfig:
+    """Generation and the benchmark read one field, so they cannot disagree."""
+
+    def test_should_read_the_version_of_this_tool(self):
+        config = {"baselines": [
+            {"tool": "grobid", "version": "0.9.1-crf", "profile": "default"},
+            {"tool": "jats-agentic-annotation", "version": "ckpt-1", "profile": "default"},
+        ]}
+        assert checkpoint_from_config(config) == "ckpt-1"
+
+    def test_should_be_none_when_the_tool_is_absent(self):
+        config = {"baselines": [{"tool": "grobid", "version": "0.9.1-crf"}]}
+        assert checkpoint_from_config(config) is None
+
+    def test_should_be_none_without_baselines(self):
+        assert checkpoint_from_config({}) is None
+
+    def test_should_match_the_shipped_config(self):
+        # The generation default has to resolve, or a dispatch with no checkpoint
+        # exits rather than running for hours.
+        with open("benchmarks/eval.yml", encoding="utf-8") as f:
+            assert checkpoint_from_config(yaml.safe_load(f))

--- a/benchmarks/tests/prediction_files_test.py
+++ b/benchmarks/tests/prediction_files_test.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from benchmarks.prediction_files import (
+    is_prediction_file,
+    iter_prediction_files,
+    record_id_from_name,
+)
+
+
+class TestIsPredictionFile:
+    def test_should_accept_tei_and_jats(self):
+        assert is_prediction_file('doc-1.tei.xml')
+        assert is_prediction_file('doc-1.jats.xml')
+
+    def test_should_reject_anything_else(self):
+        assert not is_prediction_file('manifest.jsonl')
+        assert not is_prediction_file('doc-1.xml')
+        assert not is_prediction_file('summary.json')
+
+
+class TestRecordIdFromName:
+    def test_should_strip_the_schema_suffix(self):
+        assert record_id_from_name('doc-1.tei.xml') == 'doc-1'
+        assert record_id_from_name('doc-1.jats.xml') == 'doc-1'
+
+    def test_should_keep_an_id_that_contains_the_suffix_text(self):
+        # `.stem.replace('.tei', '')` rewrote the id itself here.
+        assert record_id_from_name('a.tei.b.tei.xml') == 'a.tei.b'
+
+    def test_should_keep_dots_within_an_id(self):
+        assert record_id_from_name('10.1234.5678.jats.xml') == '10.1234.5678'
+
+
+class TestIterPredictionFiles:
+    def test_should_find_both_schemas_ordered_by_record_id(self, tmp_path: Path):
+        for name in ['b.tei.xml', 'a.jats.xml', 'c.tei.xml', 'manifest.jsonl']:
+            (tmp_path / name).write_text('x')
+        assert [p.name for p in iter_prediction_files(tmp_path)] == [
+            'a.jats.xml', 'b.tei.xml', 'c.tei.xml',
+        ]
+
+    def test_should_be_empty_for_a_missing_directory(self, tmp_path: Path):
+        assert not list(iter_prediction_files(tmp_path / 'nope'))

--- a/benchmarks/tests/predictions_store_test.py
+++ b/benchmarks/tests/predictions_store_test.py
@@ -253,3 +253,86 @@ class TestRepoStoreDoneIdsAreVariantAware:
         with patch("subprocess.run", self._git_mock({})):
             done = self._store(tmp_path).get_done_ids("grobid", "0.9", "default", "train")
         assert done == {("biorxiv", "r1"), ("biorxiv", "r2")}
+
+
+class TestRepoPredictionsStoreWithJatsPredictions:
+    """A JATS-producing tool round-trips like any other.
+
+    All three failed silently while the store looked only for `.tei.xml`.
+    """
+
+    def _store(self, tmp_path: Path) -> RepoPredictionsStore:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        return RepoPredictionsStore(repo_dir=repo)
+
+    def test_stored_ids_counts_jats_predictions(self, tmp_path: Path):
+        store = self._store(tmp_path)
+        manifest_text = (
+            json.dumps({"corpus": "biorxiv", "record_id": "doc1", "status": "ok"}) + "\n"
+        )
+        prefix = "jats-agentic-annotation/tfull/default"
+        keys = {
+            ("show", f"HEAD:{prefix}/train/manifest.jsonl"): manifest_text,
+            (
+                "ls-tree", "-r", "--name-only", "HEAD",
+                f"{prefix}/biorxiv/v1/train/",
+            ): f"{prefix}/biorxiv/v1/train/doc1.jats.xml\n",
+        }
+        with patch("subprocess.run", _make_git_mock(keys)):
+            result = store.get_done_ids(
+                "jats-agentic-annotation", "tfull", "default", "train",
+                {"biorxiv": "v1"},
+            )
+        assert result == {("biorxiv", "doc1")}
+
+    def test_fetch_copies_jats_predictions(self, tmp_path: Path):
+        store = self._store(tmp_path)
+        src = store.repo_dir / "jats-agentic-annotation/tfull/default/biorxiv/v1/train"
+        src.mkdir(parents=True)
+        (src / "doc1.jats.xml").write_text("<article/>")
+        local_dir = tmp_path / "local"
+        with patch.object(store, "_git"):
+            store.fetch(
+                "jats-agentic-annotation", "tfull", "default", "train",
+                local_dir, {"biorxiv": "v1"},
+            )
+        copied = local_dir / "predictions" / "biorxiv" / "doc1.jats.xml"
+        assert copied.read_text() == "<article/>"
+
+    def test_push_copies_jats_predictions(self, tmp_path: Path):
+        store = self._store(tmp_path)
+        local_dir = tmp_path / "local"
+        corpus_dir = local_dir / "predictions" / "biorxiv"
+        corpus_dir.mkdir(parents=True)
+        (corpus_dir / "doc1.jats.xml").write_text("<article/>")
+
+        def fake_git(*_args, **_kw):
+            result = MagicMock()
+            result.returncode = 1  # changes present
+            result.stdout = ""
+            return result
+
+        with patch.object(store, "_git", side_effect=fake_git):
+            store.push(
+                "jats-agentic-annotation", "tfull", "default", "train", local_dir,
+                {"biorxiv": "v1"}, {"tool": "jats-agentic-annotation"},
+            )
+
+        dest = (
+            store.repo_dir
+            / "jats-agentic-annotation/tfull/default/biorxiv/v1/train/doc1.jats.xml"
+        )
+        assert dest.exists()
+
+    def test_push_and_fetch_keep_tei_and_jats_side_by_side(self, tmp_path: Path):
+        store = self._store(tmp_path)
+        src = store.repo_dir / "mixed/v1/default/biorxiv/v1/train"
+        src.mkdir(parents=True)
+        (src / "doc1.tei.xml").write_text("<TEI/>")
+        (src / "doc2.jats.xml").write_text("<article/>")
+        local_dir = tmp_path / "local"
+        with patch.object(store, "_git"):
+            store.fetch("mixed", "v1", "default", "train", local_dir, {"biorxiv": "v1"})
+        names = sorted(p.name for p in (local_dir / "predictions" / "biorxiv").iterdir())
+        assert names == ["doc1.tei.xml", "doc2.jats.xml"]

--- a/benchmarks/tests/run_test.py
+++ b/benchmarks/tests/run_test.py
@@ -4,12 +4,12 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+from benchmarks.fetch import get_corpus_variants
 from benchmarks.predictions_store import LocalPredictionsStore
 from benchmarks.run import (
     _baseline_env_vars,
     _coverage,
     _run_baseline,
-    _get_corpus_variants,
     _make_label,
     _tool_docker_config,
     run_benchmark,
@@ -66,11 +66,11 @@ class TestBaselineEnvVars:
 class TestGetCorpusVariants:
     def test_reads_variant_from_config(self):
         config = {"dataset": {"splits": {"train": {"biorxiv": {"variant": "v2"}}}}}
-        assert _get_corpus_variants(config, "train") == {"biorxiv": "v2"}
+        assert get_corpus_variants(config, "train") == {"biorxiv": "v2"}
 
     def test_defaults_to_v1(self):
         config = {"dataset": {"splits": {"train": {"biorxiv": {}}}}}
-        assert _get_corpus_variants(config, "train") == {"biorxiv": "v1"}
+        assert get_corpus_variants(config, "train") == {"biorxiv": "v1"}
 
     def test_leaves_out_an_opt_in_corpus_nobody_asked_for(self):
         config = {"dataset": {"splits": {"train": {
@@ -79,8 +79,8 @@ class TestGetCorpusVariants:
         }}}}
         # Predictions for a corpus the run did not cover must be neither looked
         # for in the store nor pushed to it.
-        assert _get_corpus_variants(config, "train") == {"biorxiv": "v1"}
-        assert _get_corpus_variants(config, "train", ["plos"]) == {
+        assert get_corpus_variants(config, "train") == {"biorxiv": "v1"}
+        assert get_corpus_variants(config, "train", ["plos"]) == {
             "biorxiv": "v1", "plos": "plos-v002",
         }
 


### PR DESCRIPTION
part of https://github.com/eLifePathways/ScienceBeam2.0/issues/155

Adds the benchmark side of an LLM column: a predictor, schema-agnostic prediction storage, and a baseline entry. Nothing generates predictions yet, so the column stays absent until some exist -- the baseline is skipped with a warning rather than failing.

benchmarks/predict_llm.py drives the annotation service: preprocess each PDF to markdown, annotate front/body/back in three rollouts, merge the responses into one article, write it as JATS. The endpoint is a required argument rather than a default, so no run uploads documents anywhere by accident. A failed section fails the document, since a partial article is indistinguishable in the summary from a model that found nothing.

benchmarks/prediction_files.py fixes an assumption that would have failed silently. The store and the scorer both looked only for *.tei.xml, so a JATS-producing tool generated its predictions, stored none of them, reported every record as still missing, and regenerated the lot on the next run. Both now share one definition of what a prediction file is.

Scoring needed no new path: sciencebeam-judge picks its field mapping from the root element and the gold is already JATS, so the model's output scores through the same field definitions as GROBID's TEI. Verified by scoring a merged prediction built from a real gold document -- byte-identical sections, and 1.000 on every field that document populates.

eval.yml carries the baseline with generate: false, so PR runs read stored predictions and never need a GPU. version is the checkpoint, so a new one gets its own predictions instead of inheriting the previous one's.

Known gap: no command both generates and pushes. The predict_llm CLI writes a run directory but does not store it, and run.py only generates for this tool when eval.yml carries an endpoint and generate: true. Generating today means editing config first.

Serving is also unresolved. The checkpoints in GCS are full merged weights, but the model is an agentic policy that needs the jats_annotator tool-call environment around it, so vLLM alone is not enough -- the only endpoint that currently implements that is the Modal deployment.