### PR TITLE
LLM cost and token usage in the benchmark report

### DIFF
--- a/benchmarks/llm_usage.py
+++ b/benchmarks/llm_usage.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+SUM_KEYS = (
+    "calls", "input_tokens", "cached_input_tokens", "output_tokens", "reasoning_tokens"
+)
+MAX_KEYS = ("peak_output_tokens",)
+UNION_KEYS = ("models", "providers")
+COUNT_KEYS = ("n_attempted", "n_with_usage")
+
+
+def combine_usage(usage_entries: Iterable[dict]) -> Dict[str, Any]:
+    """Sum usage entries, keeping the peak a peak and cost absent where unstated."""
+    combined: Dict[str, Any] = {key: 0 for key in SUM_KEYS + MAX_KEYS}
+    cost: Optional[float] = None
+    union: Dict[str, List[str]] = {key: [] for key in UNION_KEYS}
+    by_task: Dict[str, List[dict]] = {}
+
+    for entry in usage_entries:
+        for key in SUM_KEYS:
+            combined[key] += entry.get(key) or 0
+        for key in MAX_KEYS:
+            combined[key] = max(combined[key], entry.get(key) or 0)
+        if entry.get("cost_credits") is not None:
+            cost = (cost or 0.0) + float(entry["cost_credits"])
+        for key in UNION_KEYS:
+            for value in entry.get(key) or []:
+                if value not in union[key]:
+                    union[key].append(value)
+        for task, task_entry in (entry.get("by_task") or {}).items():
+            by_task.setdefault(task, []).append(task_entry)
+
+    if cost is not None:
+        combined["cost_credits"] = cost
+    for key in UNION_KEYS:
+        if union[key]:
+            combined[key] = union[key]
+    if by_task:
+        combined["by_task"] = {
+            task: combine_usage(task_entries)
+            for task, task_entries in sorted(by_task.items())
+        }
+    return combined
+
+
+def read_manifest_entries(run_dir: Path) -> List[dict]:
+    manifest_path = run_dir / "predictions" / "manifest.jsonl"
+    if not manifest_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in manifest_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def aggregate_llm_usage(
+    manifest_entries: List[dict], corpora: Iterable[str]
+) -> Dict[str, Any]:
+    """Per corpus, what the LLM spent producing these predictions.
+
+    Over every document attempted, errors included, which is deliberately not the
+    subset the scores cover. Usage is summed per attempt, since a re-run paid
+    again, while the document counts are of distinct records.
+    """
+    if not any(entry.get("llm_usage") for entry in manifest_entries):
+        return {}
+
+    usage_by_corpus: Dict[str, Any] = {}
+    for corpus in corpora:
+        corpus_entries = [
+            entry for entry in manifest_entries if entry.get("corpus") == corpus
+        ]
+        if not corpus_entries:
+            continue
+        usage_by_corpus[corpus] = {
+            "n_attempted": len({entry.get("record_id") for entry in corpus_entries}),
+            "n_with_usage": len({
+                entry.get("record_id") for entry in corpus_entries
+                if entry.get("llm_usage")
+            }),
+            **combine_usage([
+                entry["llm_usage"] for entry in corpus_entries if entry.get("llm_usage")
+            ]),
+        }
+    return usage_by_corpus
+
+
+def usage_for_corpora(summary: dict, corpora: Iterable[str]) -> Optional[Dict[str, Any]]:
+    """One variant's usage over the named corpora, or None where it recorded none."""
+    per_corpus = summary.get("llm_usage") or {}
+    selected = [per_corpus[corpus] for corpus in corpora if corpus in per_corpus]
+    if not selected:
+        return None
+    return {
+        **combine_usage(selected),
+        **{
+            key: sum(entry.get(key) or 0 for entry in selected)
+            for key in COUNT_KEYS
+        },
+    }

--- a/benchmarks/predict.py
+++ b/benchmarks/predict.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import httpx
 import yaml
 
+from sciencebeam_parser.models.llm.usage import USAGE_HEADER_NAME
+
 from benchmarks.fetch import fetch_data, resolved_sources
 
 LOGGER = logging.getLogger(__name__)
@@ -49,6 +51,25 @@ def _append_manifest(run_dir: Path, entry: Dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
+
+
+def _llm_usage_entry(response: Optional[httpx.Response]) -> Dict[str, Any]:
+    """The parser's usage header, as given, or nothing.
+
+    Omitted rather than zeroed when the header is absent: a CRF-only run, a
+    timeout that produced no response at all, and a document that genuinely
+    spent nothing are three different things, and only the last is a zero.
+    """
+    if response is None:
+        return {}
+    header_value = response.headers.get(USAGE_HEADER_NAME)
+    if not header_value:
+        return {}
+    try:
+        return {"llm_usage": json.loads(header_value)}
+    except json.JSONDecodeError:
+        LOGGER.warning("Could not parse %s: %r", USAGE_HEADER_NAME, header_value[:200])
+        return {}
 
 
 def _format_eta(seconds: float) -> str:
@@ -147,6 +168,7 @@ async def _run_predict_async(
                     _append_manifest(run_dir, {
                         "corpus": corpus, "record_id": record_id,
                         "status": "ok", "elapsed_ms": elapsed_ms,
+                        **_llm_usage_entry(response),
                     })
                     progress.record_ok(corpus, record_id, elapsed_ms)
                 except httpx.HTTPStatusError as exc:
@@ -161,6 +183,7 @@ async def _run_predict_async(
                     _append_manifest(run_dir, {
                         "corpus": corpus, "record_id": record_id,
                         "status": "error", "error": msg, "error_body": body,
+                        **_llm_usage_entry(exc.response),
                     })
                     progress.record_err(corpus, record_id)
                 except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -4,7 +4,9 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from benchmarks.llm_usage import usage_for_corpora
 
 LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +57,91 @@ def _fmt_delta(delta: Optional[float]) -> str:
 
 def _corpus_f1_getter(corpus: str) -> Callable[[dict, str, str], Optional[float]]:
     return lambda s, f, m: _get_f1(s, corpus, f, m)
+
+
+USAGE_HEADERS = (
+    "Variant", "Docs with usage", "Calls", "Input tokens", "Output tokens",
+    "Output/doc", "Peak call", "Credits", "Credits/doc",
+)
+
+
+def _fmt_count(value: Optional[float]) -> str:
+    return f"{round(value):,}" if value else "—"
+
+
+def _fmt_credits(value: Optional[float], places: int = 4) -> str:
+    return f"{value:.{places}f}" if value is not None else "—"
+
+
+def _usage_row(label: str, usage: Optional[Dict[str, Any]]) -> str:
+    if not usage or not usage.get("calls"):
+        attempted = (usage or {}).get("n_attempted") or 0
+        docs = f"0 / {attempted}" if attempted else "—"
+        return f"| {label} | {docs} | " + " | ".join(["—"] * 7) + " |"
+    recorded = usage.get("n_with_usage") or 0
+    cost = usage.get("cost_credits")
+    cells = [
+        f"{recorded} / {usage.get('n_attempted') or 0}",
+        _fmt_count(usage.get("calls")),
+        _fmt_count(usage.get("input_tokens")),
+        _fmt_count(usage.get("output_tokens")),
+        _fmt_count((usage.get("output_tokens") or 0) / recorded if recorded else None),
+        _fmt_count(usage.get("peak_output_tokens")),
+        _fmt_credits(cost),
+        _fmt_credits(cost / recorded if cost is not None and recorded else None, 5),
+    ]
+    return f"| {label} | " + " | ".join(cells) + " |"
+
+
+def _render_by_task_lines(labeled_usage: List[Tuple[str, Optional[dict]]]) -> List[str]:
+    """Which model spent it, where more than one task ran."""
+    lines = []
+    for label, usage in labeled_usage:
+        by_task = (usage or {}).get("by_task") or {}
+        if len(by_task) < 2:
+            continue
+        parts = [
+            f"{task}: {entry.get('calls', 0)} calls,"
+            f" {_fmt_count(entry.get('output_tokens'))} output tokens"
+            for task, entry in by_task.items()
+        ]
+        lines.append(f"> **{label}** by task — " + "; ".join(parts))
+    return lines
+
+
+def _cached_input_note(labeled_usage: List[Tuple[str, Optional[dict]]]) -> str:
+    """Only where it happened, since a cost difference it explains is otherwise
+    attributed to the variant."""
+    cached = sum((usage or {}).get("cached_input_tokens") or 0 for _, usage in labeled_usage)
+    if not cached:
+        return ""
+    return (
+        f" Input tokens include {cached:,} served from the provider's own prefix"
+        " cache, which is where a credit difference over the same input comes from."
+    )
+
+
+def _render_usage_table(
+    labeled_summaries: List[Tuple[str, dict]],
+    corpora: List[str],
+    note: str,
+) -> List[str]:
+    """Empty unless some variant recorded usage, so a CRF-only report is unchanged."""
+    labeled_usage = [
+        (label, usage_for_corpora(summary, corpora))
+        for label, summary in labeled_summaries
+    ]
+    if not any(usage and usage.get("calls") for _, usage in labeled_usage):
+        return []
+    by_task_lines = _render_by_task_lines(labeled_usage)
+    return [
+        note + _cached_input_note(labeled_usage),
+        "",
+        "| " + " | ".join(USAGE_HEADERS) + " |",
+        "|" + "|".join(["---"] * len(USAGE_HEADERS)) + "|",
+        *[_usage_row(label, usage) for label, usage in labeled_usage],
+        *(["", *by_task_lines] if by_task_lines else []),
+    ]
 
 
 def _render_field_table(  # pylint: disable=too-many-locals
@@ -142,6 +229,12 @@ def _render_corpus_section(
         labeled_summaries, field_names, field_measures, field_scoring_types,
         _corpus_f1_getter(corpus),
     ))
+    usage_lines = _render_usage_table(
+        labeled_summaries, [corpus],
+        "**LLM usage**, over every document attempted in this corpus.",
+    )
+    if usage_lines:
+        lines += ["", *usage_lines]
     return lines
 
 
@@ -206,6 +299,17 @@ def _render_comparison_report(
             labeled_summaries, field_names, field_measures, field_scoring_types, corpora,
         ))
         lines.append("")
+
+    usage_lines = _render_usage_table(
+        labeled_summaries, corpora,
+        "### LLM usage\n\nWhat producing these predictions spent, over every document"
+        " attempted — deliberately a wider set than the scores above, since an errored"
+        " document still spent its tokens. A variant short of usage for documents it"
+        " attempted was served them from the predictions store, or produced them before"
+        " this was recorded. Cost is absent where the backend states none.",
+    )
+    if usage_lines:
+        lines += [*usage_lines, ""]
 
     for corpus in corpora:
         n_primary = primary_summary.get("corpora", {}).get(corpus, {}).get("n", 0)

--- a/benchmarks/score.py
+++ b/benchmarks/score.py
@@ -19,6 +19,7 @@ from sciencebeam_judge.parsing.xpath.xpath_functions import register_functions
 from sciencebeam_judge.resources import DEFAULT_XML_MAPPING_PATH
 
 from benchmarks.fetch import included_corpora
+from benchmarks.llm_usage import aggregate_llm_usage, read_manifest_entries
 
 LOGGER = logging.getLogger(__name__)
 
@@ -258,11 +259,14 @@ def run_score(  # pylint: disable=too-many-locals,too-many-arguments,too-many-po
             field_scoring_types, xml_mapping
         )
 
+    llm_usage = aggregate_llm_usage(read_manifest_entries(run_dir), corpora)
+
     (run_dir / "summary.json").write_text(json.dumps({
         "fields": field_names,
         "field_measures": field_measures,
         "field_scoring_types": field_scoring_types,
         "corpora": corpus_results,
+        **({"llm_usage": llm_usage} if llm_usage else {}),
     }, indent=2))
 
     report = _render_report(corpus_results, field_names, field_scoring_types, run_record)

--- a/benchmarks/tests/llm_usage_test.py
+++ b/benchmarks/tests/llm_usage_test.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from benchmarks.llm_usage import (
+    aggregate_llm_usage,
+    combine_usage,
+    read_manifest_entries,
+    usage_for_corpora,
+)
+
+
+def _usage(
+    calls: int = 1,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    peak_output_tokens: Optional[int] = None,
+    cost: Optional[float] = 0.0004,
+    task: str = "citation",
+    model: str = "qwen/qwen3.5-9b",
+) -> dict:
+    entry = {
+        "calls": calls,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "reasoning_tokens": 0,
+        "peak_output_tokens": (
+            output_tokens if peak_output_tokens is None else peak_output_tokens
+        ),
+        "models": [model],
+        "providers": ["SiliconFlow"],
+    }
+    if cost is not None:
+        entry["cost_credits"] = cost
+    entry["by_task"] = {task: dict(entry)}
+    return entry
+
+
+def _manifest_entry(
+    corpus: str = "biorxiv",
+    record_id: str = "doc1",
+    status: str = "ok",
+    usage: Optional[dict] = None,
+) -> dict:
+    entry: dict = {"corpus": corpus, "record_id": record_id, "status": status}
+    if usage is not None:
+        entry["llm_usage"] = usage
+    return entry
+
+
+class TestCombineUsage:
+    def test_should_sum_tokens_and_calls(self):
+        combined = combine_usage([_usage(), _usage()])
+        assert combined["calls"] == 2
+        assert combined["input_tokens"] == 200
+        assert combined["output_tokens"] == 100
+
+    def test_should_keep_the_peak_as_a_peak(self):
+        combined = combine_usage([
+            _usage(output_tokens=50), _usage(output_tokens=16000)
+        ])
+        assert combined["output_tokens"] == 16050
+        assert combined["peak_output_tokens"] == 16000
+
+    def test_should_sum_cost_where_stated(self):
+        combined = combine_usage([_usage(cost=0.001), _usage(cost=0.002)])
+        assert combined["cost_credits"] == 0.003
+
+    def test_should_leave_cost_absent_where_never_stated(self):
+        combined = combine_usage([_usage(cost=None), _usage(cost=None)])
+        assert "cost_credits" not in combined
+        assert combined["output_tokens"] == 100
+
+    def test_should_combine_by_task(self):
+        combined = combine_usage([
+            _usage(task="citation", output_tokens=50),
+            _usage(task="reference_segmenter", output_tokens=900),
+        ])
+        assert combined["by_task"]["citation"]["output_tokens"] == 50
+        assert combined["by_task"]["reference_segmenter"]["output_tokens"] == 900
+
+    def test_should_list_each_model_once(self):
+        combined = combine_usage([_usage(model="a"), _usage(model="a"), _usage(model="b")])
+        assert combined["models"] == ["a", "b"]
+
+    def test_should_be_empty_for_no_entries(self):
+        combined = combine_usage([])
+        assert combined["calls"] == 0
+        assert "cost_credits" not in combined
+
+
+class TestAggregateLlmUsage:
+    def test_should_be_empty_when_no_entry_carries_usage(self):
+        entries = [_manifest_entry(), _manifest_entry(record_id="doc2")]
+        assert not aggregate_llm_usage(entries, ["biorxiv"])
+
+    def test_should_aggregate_per_corpus(self):
+        entries = [
+            _manifest_entry(corpus="biorxiv", record_id="doc1", usage=_usage()),
+            _manifest_entry(corpus="plos", record_id="doc2", usage=_usage(calls=2)),
+        ]
+        usage = aggregate_llm_usage(entries, ["biorxiv", "plos"])
+        assert usage["biorxiv"]["calls"] == 1
+        assert usage["plos"]["calls"] == 2
+
+    def test_should_include_a_document_that_errored(self):
+        entries = [
+            _manifest_entry(record_id="doc1", usage=_usage()),
+            _manifest_entry(record_id="doc2", status="error", usage=_usage()),
+        ]
+        usage = aggregate_llm_usage(entries, ["biorxiv"])
+        assert usage["biorxiv"]["n_attempted"] == 2
+        assert usage["biorxiv"]["n_with_usage"] == 2
+        assert usage["biorxiv"]["calls"] == 2
+
+    def test_should_count_documents_without_usage_as_attempted(self):
+        entries = [
+            _manifest_entry(record_id="doc1", usage=_usage()),
+            _manifest_entry(record_id="doc2"),
+        ]
+        usage = aggregate_llm_usage(entries, ["biorxiv"])
+        assert usage["biorxiv"]["n_attempted"] == 2
+        assert usage["biorxiv"]["n_with_usage"] == 1
+
+    def test_should_count_a_document_once_but_sum_every_attempt(self):
+        entries = [
+            _manifest_entry(record_id="doc1", status="error", usage=_usage()),
+            _manifest_entry(record_id="doc1", usage=_usage()),
+        ]
+        usage = aggregate_llm_usage(entries, ["biorxiv"])
+        assert usage["biorxiv"]["n_attempted"] == 1
+        assert usage["biorxiv"]["calls"] == 2
+
+    def test_should_leave_out_a_corpus_without_entries(self):
+        entries = [_manifest_entry(usage=_usage())]
+        usage = aggregate_llm_usage(entries, ["biorxiv", "plos"])
+        assert list(usage) == ["biorxiv"]
+
+
+class TestReadManifestEntries:
+    def test_should_be_empty_without_a_manifest(self, tmp_path):
+        assert read_manifest_entries(tmp_path) == []
+
+    def test_should_read_entries_and_ignore_blank_lines(self, tmp_path):
+        manifest = tmp_path / "predictions" / "manifest.jsonl"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            '{"corpus": "biorxiv", "record_id": "doc1"}\n\n'
+            '{"corpus": "biorxiv", "record_id": "doc2"}\n'
+        )
+        assert [entry["record_id"] for entry in read_manifest_entries(tmp_path)] == [
+            "doc1", "doc2"
+        ]
+
+
+class TestUsageForCorpora:
+    def test_should_be_none_without_recorded_usage(self):
+        assert usage_for_corpora({"corpora": {}}, ["biorxiv"]) is None
+
+    def test_should_sum_across_the_named_corpora(self):
+        summary = {
+            "llm_usage": {
+                "biorxiv": {"n_attempted": 2, "n_with_usage": 2, **_usage(calls=2)},
+                "plos": {"n_attempted": 1, "n_with_usage": 1, **_usage(calls=1)},
+            }
+        }
+        usage = usage_for_corpora(summary, ["biorxiv", "plos"])
+        assert usage is not None
+        assert usage["calls"] == 3
+        assert usage["n_attempted"] == 3
+        assert usage["n_with_usage"] == 3
+
+    def test_should_ignore_a_corpus_it_has_no_usage_for(self):
+        summary = {
+            "llm_usage": {
+                "biorxiv": {"n_attempted": 2, "n_with_usage": 1, **_usage()},
+            }
+        }
+        usage = usage_for_corpora(summary, ["biorxiv", "plos"])
+        assert usage is not None
+        assert usage["n_attempted"] == 2

--- a/benchmarks/tests/predict_test.py
+++ b/benchmarks/tests/predict_test.py
@@ -4,18 +4,30 @@ import asyncio
 import json
 import os
 from pathlib import Path
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
+from sciencebeam_parser.models.llm.usage import USAGE_HEADER_NAME
+
 from benchmarks.predict import (
     _append_manifest,
     _format_eta,
+    _llm_usage_entry,
     _load_done,
     _Progress,
     _resolve_concurrency,
     _run_predict_async,
 )
+
+LLM_USAGE_1 = {
+    "calls": 4,
+    "input_tokens": 400,
+    "output_tokens": 200,
+    "cost_credits": 0.0016,
+    "by_task": {"citation": {"calls": 4, "output_tokens": 200}},
+}
 
 
 class TestLoadDone:
@@ -142,9 +154,16 @@ def _make_record(tmp_path: Path, corpus: str = "biorxiv", record_id: str = "doc1
     return {"corpus": corpus, "record_id": record_id, "pdf_path": str(pdf)}
 
 
-def _mock_client(content: bytes = b"<tei/>") -> AsyncMock:
+def _usage_headers(usage: Optional[dict]) -> dict:
+    return {} if usage is None else {USAGE_HEADER_NAME: json.dumps(usage)}
+
+
+def _mock_client(
+    content: bytes = b"<tei/>", usage: Optional[dict] = None
+) -> AsyncMock:
     mock_response = MagicMock()
     mock_response.content = content
+    mock_response.headers = _usage_headers(usage)
     mock_response.raise_for_status = MagicMock(return_value=None)
     client = AsyncMock()
     client.__aenter__ = AsyncMock(return_value=client)
@@ -153,20 +172,34 @@ def _mock_client(content: bytes = b"<tei/>") -> AsyncMock:
     return client
 
 
-def _mock_client_http_error(status_code: int = 500, body: str = "server error") -> AsyncMock:
+def _mock_client_http_error(
+    status_code: int = 500,
+    body: str = "server error",
+    usage: Optional[dict] = None,
+) -> AsyncMock:
     error_response = MagicMock()
     error_response.text = body
+    error_response.headers = _usage_headers(usage)
     exc = httpx.HTTPStatusError(
         f"Server error '{status_code}'",
         request=MagicMock(),
         response=error_response,
     )
     mock_response = MagicMock()
+    mock_response.headers = _usage_headers(usage)
     mock_response.raise_for_status = MagicMock(side_effect=exc)
     client = AsyncMock()
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
     client.post = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _mock_client_timeout() -> AsyncMock:
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
     return client
 
 
@@ -245,3 +278,73 @@ class TestRunPredictAsync:
         entries = self._read_manifest(run_dir)
         assert entries[0]["status"] == "error"
         assert "connection refused" in entries[0]["error"]
+
+
+class TestLlmUsageEntry:
+    def test_should_be_empty_without_a_response(self):
+        assert not _llm_usage_entry(None)
+
+    def test_should_be_empty_without_the_header(self):
+        response = MagicMock()
+        response.headers = {}
+        assert not _llm_usage_entry(response)
+
+    def test_should_return_the_header_as_given(self):
+        response = MagicMock()
+        response.headers = {USAGE_HEADER_NAME: json.dumps(LLM_USAGE_1)}
+        assert _llm_usage_entry(response) == {"llm_usage": LLM_USAGE_1}
+
+    def test_should_be_empty_for_an_unparseable_header(self):
+        response = MagicMock()
+        response.headers = {USAGE_HEADER_NAME: "{not json"}
+        assert not _llm_usage_entry(response)
+
+
+class TestManifestLlmUsage:
+    def _read_manifest(self, run_dir: Path) -> list:
+        path = run_dir / "predictions" / "manifest.jsonl"
+        return [
+            json.loads(line) for line in path.read_text().splitlines() if line.strip()
+        ]
+
+    def test_should_record_usage_of_a_successful_document(self, tmp_path: Path):
+        run_dir = tmp_path / "run"
+        client = _mock_client(usage=LLM_USAGE_1)
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=client):
+            asyncio.run(_run_predict_async(
+                [_make_record(tmp_path)], set(), run_dir, "http://localhost:8080", 60, 1
+            ))
+        assert self._read_manifest(run_dir)[0]["llm_usage"] == LLM_USAGE_1
+
+    def test_should_record_usage_of_a_document_that_errored(self, tmp_path: Path):
+        run_dir = tmp_path / "run"
+        client = _mock_client_http_error(500, "traceback here", usage=LLM_USAGE_1)
+        with patch("benchmarks.predict.httpx.AsyncClient", return_value=client):
+            asyncio.run(_run_predict_async(
+                [_make_record(tmp_path)], set(), run_dir, "http://localhost:8080", 60, 1
+            ))
+        entry = self._read_manifest(run_dir)[0]
+        assert entry["status"] == "error"
+        assert entry["llm_usage"] == LLM_USAGE_1
+
+    def test_should_omit_usage_rather_than_zero_it_without_a_header(self, tmp_path: Path):
+        run_dir = tmp_path / "run"
+        with patch(
+            "benchmarks.predict.httpx.AsyncClient", return_value=_mock_client()
+        ):
+            asyncio.run(_run_predict_async(
+                [_make_record(tmp_path)], set(), run_dir, "http://localhost:8080", 60, 1
+            ))
+        assert "llm_usage" not in self._read_manifest(run_dir)[0]
+
+    def test_should_omit_usage_when_no_response_arrived(self, tmp_path: Path):
+        run_dir = tmp_path / "run"
+        with patch(
+            "benchmarks.predict.httpx.AsyncClient", return_value=_mock_client_timeout()
+        ):
+            asyncio.run(_run_predict_async(
+                [_make_record(tmp_path)], set(), run_dir, "http://localhost:8080", 60, 1
+            ))
+        entry = self._read_manifest(run_dir)[0]
+        assert entry["status"] == "error"
+        assert "llm_usage" not in entry

--- a/benchmarks/tests/report_test.py
+++ b/benchmarks/tests/report_test.py
@@ -355,3 +355,159 @@ class TestOverallRestrictedToCommonCorpora:
         # The unequal-columns warning belongs to b's own section, not the overall row.
         overall = report.split("<details>", maxsplit=1)[0]
         assert "Unequal document sets" not in overall
+
+
+def _usage(
+    calls: int = 8,
+    input_tokens: int = 800,
+    output_tokens: int = 400,
+    peak_output_tokens: int = 120,
+    cost: Optional[float] = 0.0032,
+    n_attempted: int = 10,
+    n_with_usage: int = 10,
+    by_task: Optional[dict] = None,
+) -> dict:
+    entry: dict = {
+        "n_attempted": n_attempted,
+        "n_with_usage": n_with_usage,
+        "calls": calls,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "reasoning_tokens": 0,
+        "peak_output_tokens": peak_output_tokens,
+    }
+    if cost is not None:
+        entry["cost_credits"] = cost
+    if by_task is not None:
+        entry["by_task"] = by_task
+    return entry
+
+
+def _with_usage(summary: dict, usage_by_corpus: dict) -> dict:
+    return {**summary, "llm_usage": usage_by_corpus}
+
+
+class TestRenderUsageSection:
+    def _labeled(self, crf_usage=None, llm_usage=None, corpora=None):
+        corpora = corpora or ["biorxiv"]
+        agg = [_agg("string", "levenshtein", {"title": 0.8})]
+        crf = _title_summary(0.8, corpora=_multi_corpus(corpora, agg))
+        llm = _title_summary(0.85, corpora=_multi_corpus(corpora, agg))
+        return [
+            ("crf (default)", _with_usage(crf, crf_usage) if crf_usage else crf),
+            ("llm (values)", _with_usage(llm, llm_usage) if llm_usage else llm),
+        ]
+
+    def test_should_not_render_a_section_without_any_usage(self):
+        report = _render_comparison_report(self._labeled())
+        assert "LLM usage" not in report
+
+    def test_should_render_totals_for_the_variant_that_spent(self):
+        report = _render_comparison_report(
+            self._labeled(llm_usage={"biorxiv": _usage()})
+        )
+        assert "LLM usage" in report
+        usage_row = next(
+            line for line in report.splitlines() if line.startswith("| llm (values)")
+        )
+        assert "10 / 10" in usage_row
+        assert "800" in usage_row
+        assert "0.0032" in usage_row
+
+    def test_should_state_that_it_covers_every_document_attempted(self):
+        report = _render_comparison_report(
+            self._labeled(llm_usage={"biorxiv": _usage()})
+        )
+        assert "every document attempted" in report
+
+    def test_should_show_a_variant_without_usage_as_absent(self):
+        report = _render_comparison_report(
+            self._labeled(llm_usage={"biorxiv": _usage()})
+        )
+        crf_row = next(
+            line for line in report.splitlines() if line.startswith("| crf (default)")
+        )
+        assert "—" in crf_row
+        assert "0.0032" not in crf_row
+
+    def test_should_show_cost_as_absent_when_the_backend_stated_none(self):
+        report = _render_comparison_report(
+            self._labeled(llm_usage={"biorxiv": _usage(cost=None)})
+        )
+        usage_row = next(
+            line for line in report.splitlines() if line.startswith("| llm (values)")
+        )
+        assert "800" in usage_row
+        assert usage_row.rstrip().endswith("— | — |")
+
+    def test_should_show_partly_recorded_usage_as_a_fraction(self):
+        report = _render_comparison_report(
+            self._labeled(llm_usage={"biorxiv": _usage(n_attempted=10, n_with_usage=4)})
+        )
+        usage_row = next(
+            line for line in report.splitlines() if line.startswith("| llm (values)")
+        )
+        assert "4 / 10" in usage_row
+
+    def test_should_render_a_usage_table_per_corpus(self):
+        corpora = ["biorxiv", "ore"]
+        report = _render_comparison_report(self._labeled(
+            llm_usage={
+                "biorxiv": _usage(calls=8),
+                "ore": _usage(calls=2),
+            },
+            corpora=corpora,
+        ))
+        assert report.count("**LLM usage**, over every document attempted in this corpus.") == 2
+
+    def test_should_sum_corpora_in_the_overall_table(self):
+        report = _render_comparison_report(self._labeled(
+            llm_usage={
+                "biorxiv": _usage(calls=8, n_attempted=10, n_with_usage=10),
+                "ore": _usage(calls=2, n_attempted=5, n_with_usage=5),
+            },
+            corpora=["biorxiv", "ore"],
+        ))
+        overall_row = next(
+            line for line in report.splitlines()
+            if line.startswith("| llm (values)")
+        )
+        assert "15 / 15" in overall_row
+        assert "| 10 |" in overall_row
+
+    def test_should_name_the_tasks_when_more_than_one_ran(self):
+        report = _render_comparison_report(self._labeled(llm_usage={
+            "biorxiv": _usage(by_task={
+                "citation": {"calls": 6, "output_tokens": 300},
+                "reference_segmenter": {"calls": 2, "output_tokens": 100},
+            })
+        }))
+        assert "by task — citation: 6 calls" in report
+        assert "reference_segmenter: 2 calls" in report
+
+    def test_should_not_name_a_single_task(self):
+        report = _render_comparison_report(self._labeled(llm_usage={
+            "biorxiv": _usage(by_task={"citation": {"calls": 8, "output_tokens": 400}})
+        }))
+        assert "by task" not in report
+
+
+class TestCachedInputNote:
+    def _labeled(self, usage_by_corpus):
+        agg = [_agg("string", "levenshtein", {"title": 0.8})]
+        crf = _title_summary(0.8, corpora=_multi_corpus(["biorxiv"], agg))
+        llm = _title_summary(0.85, corpora=_multi_corpus(["biorxiv"], agg))
+        return [
+            ("crf", crf),
+            ("llm", _with_usage(llm, usage_by_corpus)),
+        ]
+
+    def test_should_explain_a_provider_cache_where_it_happened(self):
+        usage = {**_usage(), "cached_input_tokens": 18432}
+        report = _render_comparison_report(self._labeled({"biorxiv": usage}))
+        assert "18,432 served from the provider's own prefix cache" in report
+
+    def test_should_stay_silent_where_nothing_was_cached(self):
+        usage = {**_usage(), "cached_input_tokens": 0}
+        report = _render_comparison_report(self._labeled({"biorxiv": usage}))
+        assert "prefix cache" not in report

--- a/benchmarks/tests/score_test.py
+++ b/benchmarks/tests/score_test.py
@@ -366,3 +366,57 @@ class TestRunScoreCorpusSelection:
             tmp_path, run_json={"split": "validation", "corpora": ["ore", "plos"]}
         )
         assert scored == ["ore", "plos"]
+
+
+class TestRunScoreLlmUsage:
+    _CONFIG = {
+        "dataset": {"splits": {"train": {"biorxiv": {}}}},
+        "fields": ["title"],
+        "scoring": {
+            "default_methods": ["levenshtein"],
+            "default_type": "string",
+            "per_field": {},
+        },
+    }
+
+    def _run(self, tmp_path: Path, manifest_entries: list) -> dict:
+        run_dir = tmp_path / "run"
+        manifest = run_dir / "predictions" / "manifest.jsonl"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            "".join(json.dumps(entry) + "\n" for entry in manifest_entries)
+        )
+        with patch("benchmarks.score.register_functions"), \
+             patch("benchmarks.score.parse_xml_mapping"), \
+             patch("benchmarks.score._score_corpus", return_value={"n": 1}):
+            run_score(
+                config=self._CONFIG,
+                run_dir=run_dir,
+                data_dir=tmp_path / "data",
+                out_path=tmp_path / "report.md",
+                split_override="train",
+            )
+        return json.loads((run_dir / "summary.json").read_text())
+
+    def test_should_aggregate_usage_from_the_manifest(self, tmp_path: Path):
+        summary = self._run(tmp_path, [
+            {
+                "corpus": "biorxiv", "record_id": "doc1", "status": "ok",
+                "llm_usage": {"calls": 2, "input_tokens": 200, "output_tokens": 100},
+            },
+            {
+                "corpus": "biorxiv", "record_id": "doc2", "status": "error",
+                "llm_usage": {"calls": 1, "input_tokens": 100, "output_tokens": 16000},
+            },
+        ])
+        usage = summary["llm_usage"]["biorxiv"]
+        assert usage["calls"] == 3
+        assert usage["output_tokens"] == 16100
+        assert usage["n_attempted"] == 2
+        assert usage["n_with_usage"] == 2
+
+    def test_should_leave_the_summary_unchanged_without_usage(self, tmp_path: Path):
+        summary = self._run(tmp_path, [
+            {"corpus": "biorxiv", "record_id": "doc1", "status": "ok"},
+        ])
+        assert "llm_usage" not in summary

--- a/doc/llm_engine.md
+++ b/doc/llm_engine.md
@@ -185,6 +185,49 @@ is not a new disclosure when the same text is already going to the model, but se
 else is. Set `record_trace_content: false` in the model config to keep the metrics and drop the
 text.
 
+## What a request spent
+
+Every response to a document endpoint that used the engine carries an
+`X-ScienceBeam-LLM-Usage` header: a JSON object with what that request spent, in total and broken
+down by task. A request that made no completion call carries no header at all, so a CRF-only profile
+is unaffected.
+
+```json
+{
+  "calls": 8,
+  "input_tokens": 24960,
+  "cached_input_tokens": 18432,
+  "output_tokens": 7200,
+  "reasoning_tokens": 0,
+  "peak_output_tokens": 1240,
+  "cost_credits": 0.0071,
+  "models": ["qwen/qwen3.5-9b"],
+  "providers": ["SiliconFlow"],
+  "by_task": {"citation": {"calls": 8, "...": "..."}}
+}
+```
+
+`reasoning_tokens` and `cached_input_tokens` are **breakdowns, not additions**: the provider reports
+`prompt_tokens + completion_tokens` as its `total_tokens`, with reasoning counted inside the
+completion and provider-cached tokens inside the prompt. `peak_output_tokens` is the largest single
+call, which is what to compare against `max_output_tokens` — a document's total rises with its
+reference list and says nothing about the ceiling.
+
+`cost_credits` is OpenRouter credits, exactly as the provider reported them for those calls, and is
+**absent, not zero,** where the backend reports none — as a self-hosted endpoint does. It is not
+derived from a rate table here, so whatever the provider did or did not discount is already in the
+number. `cached_input_tokens` is why two runs over the same input can report the same tokens and
+different credits, and the benchmark report notes it where it is non-zero. This is the provider's
+own prefix caching, unrelated to any response cache of ours.
+
+A response the engine could not use has still been paid for, so a request that fails reports what it
+spent before failing: the header is on the 500 as well as the 200. A request that produced no
+response at all — a client-side timeout — reports nothing, which is not the same as zero.
+
+`benchmarks/predict.py` records the header per document in `predictions/manifest.jsonl`,
+`benchmarks/score.py` aggregates it per corpus into `summary.json`, and `benchmarks/report.py` puts
+it in `comparison.md` beside the scores.
+
 ## Input size
 
 What the engine receives is whatever the *segmentation* model labelled `<references>`, which is not
@@ -233,7 +276,9 @@ workflow adds `--include-corpus plos-manuscripts` automatically on `main`, so an
 fails rather than sending private manuscripts to a third party. Point the engine at a self-hosted
 endpoint if that corpus needs covering.
 
-Nothing is traced in CI: no collector endpoint is set, so the engine emits no spans.
+Nothing is traced in CI: no collector endpoint is set, so the engine emits no spans. What a run
+spent still reaches the job summary and the PR comment, through the usage header and the benchmark's
+own manifest rather than through a collector.
 
 Unit tests reach no network. The engine's tests are fixture-driven and the client is a `Protocol`, so
 the ordinary CI job needs no secret at all.

--- a/sciencebeam_parser/models/llm/model_impl.py
+++ b/sciencebeam_parser/models/llm/model_impl.py
@@ -1,3 +1,4 @@
+import contextvars
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Tuple
@@ -25,6 +26,7 @@ from sciencebeam_parser.models.llm.features import get_feature_column_index
 from sciencebeam_parser.models.llm.prompt import get_prompt
 from sciencebeam_parser.models.llm.tasks import get_citation_labels
 from sciencebeam_parser.models.llm.telemetry import llm_span, set_response_attributes
+from sciencebeam_parser.models.llm.usage import record_llm_usage
 from sciencebeam_parser.models.llm.values import (
     decode_batched_values_response,
     get_batched_values_response_schema,
@@ -138,9 +140,18 @@ class LlmModelImpl(ModelImpl):
             # Batches are independent, so the wall-clock is the slowest batch
             # rather than their sum. Order is preserved by mapping rather than
             # completion order, and the first exception propagates.
+            #
+            # A worker thread starts with an empty context, so the request's usage
+            # accumulator is not merely stale there but unbound, and has to be
+            # carried in. One copy per batch: entering the same Context from two
+            # workers at once raises.
+            contexts = [contextvars.copy_context() for _ in batches]
             with ThreadPoolExecutor(max_workers=workers) as pool:
                 per_batch = list(pool.map(
-                    self._predict_labels_splitting_on_truncation, batches
+                    lambda context, batch: context.run(
+                        self._predict_labels_splitting_on_truncation, batch
+                    ),
+                    contexts, batches
                 ))
         return [labelled for batch in per_batch for labelled in batch]
 
@@ -308,6 +319,7 @@ class LlmModelImpl(ModelImpl):
     ) -> List[Tuple[str, str]]:
         with llm_span(self.config, prompt, self.config.record_trace_content) as span:
             response_json = self.client.get_completion(prompt, schema)
+            record_llm_usage(self.config.task, response_json)
             span.set_attribute('sciencebeam.input_lines', max(line_numbers) + 1)
             span.set_attribute('sciencebeam.input_tokens', len(tokens))
             set_response_attributes(
@@ -382,6 +394,7 @@ class LlmModelImpl(ModelImpl):
             response_json = self.client.get_completion(
                 prompt, get_batched_values_response_schema(self.labels)
             )
+            record_llm_usage(self.config.task, response_json)
             span.set_attribute('sciencebeam.input_tokens', token_count)
             span.set_attribute('sciencebeam.batch_size', len(token_lists))
             set_response_attributes(

--- a/sciencebeam_parser/models/llm/telemetry.py
+++ b/sciencebeam_parser/models/llm/telemetry.py
@@ -176,7 +176,7 @@ def set_response_attributes(
             for attribute in attributes:
                 span.set_attribute(attribute, usage[key])
     if usage.get('cost') is not None:
-        span.set_attribute('sciencebeam.cost_usd', usage['cost'])
+        span.set_attribute('sciencebeam.cost_credits', usage['cost'])
     response_model = response_json.get('model')
     if response_model:
         span.set_attribute(GEN_AI_RESPONSE_MODEL, response_model)

--- a/sciencebeam_parser/models/llm/usage.py
+++ b/sciencebeam_parser/models/llm/usage.py
@@ -1,0 +1,140 @@
+import contextvars
+import json
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+
+USAGE_HEADER_NAME = 'X-ScienceBeam-LLM-Usage'
+
+
+@dataclass
+class LlmUsage:
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    # A subset of output_tokens, as the provider reports it, never an addition to
+    # it: prompt_tokens + completion_tokens is the reported total_tokens.
+    reasoning_tokens: int = 0
+    # A subset of input_tokens, served from the provider's own prefix cache. Cost
+    # is already net of the discount, so two runs with the same input tokens can
+    # differ in credits.
+    cached_input_tokens: int = 0
+    peak_output_tokens: int = 0
+    cost: Optional[float] = None
+    models: list = field(default_factory=list)
+    providers: list = field(default_factory=list)
+
+    def add_usage(self, usage: Mapping[str, Any]) -> None:
+        output_tokens = _get_int(usage.get('completion_tokens'))
+        self.calls += 1
+        self.input_tokens += _get_int(usage.get('prompt_tokens'))
+        self.output_tokens += output_tokens
+        self.reasoning_tokens += _get_int(
+            (usage.get('completion_tokens_details') or {}).get('reasoning_tokens')
+        )
+        self.cached_input_tokens += _get_int(
+            (usage.get('prompt_tokens_details') or {}).get('cached_tokens')
+        )
+        self.peak_output_tokens = max(self.peak_output_tokens, output_tokens)
+        cost = usage.get('cost')
+        if cost is not None:
+            self.cost = (self.cost or 0.0) + float(cost)
+
+    def add_model(self, model: Optional[str], provider: Optional[str]) -> None:
+        for value, values in ((model, self.models), (provider, self.providers)):
+            if value and value not in values:
+                values.append(value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        entry: Dict[str, Any] = {
+            'calls': self.calls,
+            'input_tokens': self.input_tokens,
+            'cached_input_tokens': self.cached_input_tokens,
+            'output_tokens': self.output_tokens,
+            'reasoning_tokens': self.reasoning_tokens,
+            'peak_output_tokens': self.peak_output_tokens,
+        }
+        # Absent rather than zero: a self-hosted endpoint reports no cost, and a
+        # zero would read as free.
+        if self.cost is not None:
+            entry['cost_credits'] = self.cost
+        if self.models:
+            entry['models'] = list(self.models)
+        if self.providers:
+            entry['providers'] = list(self.providers)
+        return entry
+
+
+def _get_int(value: Any) -> int:
+    return int(value) if isinstance(value, (int, float)) else 0
+
+
+class LlmUsageAccumulator:
+    """What one request spent, in total and per task.
+
+    Mutable and lock-guarded, because the batches of one document are answered
+    from a thread pool and several requests are in flight at once.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._total = LlmUsage()
+        self._by_task: Dict[str, LlmUsage] = {}
+
+    @property
+    def calls(self) -> int:
+        with self._lock:
+            return self._total.calls
+
+    def add_response(self, task: str, response_json: Mapping[str, Any]) -> None:
+        usage = response_json.get('usage') or {}
+        model = response_json.get('model')
+        provider = response_json.get('provider')
+        with self._lock:
+            for entry in (self._total, self._by_task.setdefault(task, LlmUsage())):
+                entry.add_usage(usage)
+                entry.add_model(model, provider)
+
+    def to_dict(self) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            if not self._total.calls:
+                return None
+            return {
+                **self._total.to_dict(),
+                'by_task': {
+                    task: entry.to_dict()
+                    for task, entry in sorted(self._by_task.items())
+                },
+            }
+
+
+REQUEST_LLM_USAGE: contextvars.ContextVar[Optional[LlmUsageAccumulator]] = (
+    contextvars.ContextVar('request_llm_usage', default=None)
+)
+
+
+def start_request_llm_usage() -> LlmUsageAccumulator:
+    """Bind a fresh accumulator to the calling task's context.
+
+    Deliberately not reset afterwards: an exception handler runs above whatever
+    binds this and has to still be able to read it, and every request task and
+    every threadpool call gets its own copy of the context anyway.
+    """
+    accumulator = LlmUsageAccumulator()
+    REQUEST_LLM_USAGE.set(accumulator)
+    return accumulator
+
+
+def record_llm_usage(task: str, response_json: Mapping[str, Any]) -> None:
+    accumulator = REQUEST_LLM_USAGE.get()
+    if accumulator is not None:
+        accumulator.add_response(task, response_json)
+
+
+def get_request_llm_usage_header_value() -> Optional[str]:
+    accumulator = REQUEST_LLM_USAGE.get()
+    if accumulator is None:
+        return None
+    usage = accumulator.to_dict()
+    return None if usage is None else json.dumps(usage)

--- a/sciencebeam_parser/service/api/app.py
+++ b/sciencebeam_parser/service/api/app.py
@@ -2,7 +2,8 @@ import logging
 
 from fastapi import (
     FastAPI,
-    Request
+    Request,
+    Response
 )
 from fastapi.responses import JSONResponse
 
@@ -10,6 +11,11 @@ from fastapi.responses import JSONResponse
 from sciencebeam_parser.app.parser import (
     ScienceBeamParser,
     UnsupportedRequestMediaTypeScienceBeamParserError
+)
+from sciencebeam_parser.models.llm.usage import (
+    USAGE_HEADER_NAME,
+    get_request_llm_usage_header_value,
+    start_request_llm_usage
 )
 from sciencebeam_parser.service.api.routers.convert import create_convert_router
 from sciencebeam_parser.service.api.routers.grobid import create_grobid_router
@@ -37,16 +43,33 @@ def create_api_app(
         sciencebeam_parser=sciencebeam_parser
     ))
 
+    def with_llm_usage_header(response: Response) -> Response:
+        header_value = get_request_llm_usage_header_value()
+        if header_value is not None:
+            response.headers[USAGE_HEADER_NAME] = header_value
+        return response
+
+    @app.middleware('http')
+    async def add_llm_usage_header(request: Request, call_next):
+        """What the request spent, beside the body rather than in it.
+
+        The accumulator is created here, in the request's own task, so that the
+        exception handler below can still read it: a document that failed has
+        already paid for the responses it got.
+        """
+        start_request_llm_usage()
+        return with_llm_usage_header(await call_next(request))
+
     @app.exception_handler(Exception)
     async def log_unhandled_exceptions(
         request: Request,
         exc: Exception  # pylint: disable=unused-argument
     ):
         LOGGER.exception("Unhandled exception on %s %s", request.method, request.url)
-        return JSONResponse(
+        return with_llm_usage_header(JSONResponse(
             status_code=500,
             content={"detail": "Internal Server Error"},
-        )
+        ))
 
     @app.exception_handler(UnsupportedRequestMediaTypeScienceBeamParserError)
     async def handle_unsupported_request_media_type(

--- a/tests/models/llm/model_impl_test.py
+++ b/tests/models/llm/model_impl_test.py
@@ -1,3 +1,4 @@
+import contextvars
 import json
 import threading
 from typing import Any, List, Mapping, Optional
@@ -12,6 +13,7 @@ from sciencebeam_parser.models.llm.decode import (
 )
 from sciencebeam_parser.models.llm.features import get_feature_column_index
 from sciencebeam_parser.models.llm.model_impl import LlmModelImpl
+from sciencebeam_parser.models.llm.usage import start_request_llm_usage
 from sciencebeam_parser.models.llm.values import render_numbered_references
 
 
@@ -671,3 +673,122 @@ class TestCitationConcurrency:
             client=FakeClient(content=batched([]))
         )
         assert len(model_impl.predict_labels(token_lists, no_features(token_lists))) == 2
+
+
+class UsageClient:
+    """Reports usage per call, and can be made to block until several calls are
+    in flight at once. `content` may be a list, one entry per call."""
+    def __init__(
+        self,
+        content,
+        completion_tokens: int = 50,
+        concurrent_calls: int = 0
+    ):
+        self.contents = content if isinstance(content, list) else [content]
+        self.completion_tokens = completion_tokens
+        self.lock = threading.Lock()
+        self.prompts: List[str] = []
+        self.barrier = (
+            threading.Barrier(concurrent_calls, timeout=5)
+            if concurrent_calls else None
+        )
+
+    def validate_configuration(self) -> None:
+        pass
+
+    def get_completion(self, prompt: str, response_schema: Mapping[str, Any]):
+        assert response_schema['type'] == 'object'
+        if self.barrier is not None:
+            self.barrier.wait()
+        with self.lock:
+            self.prompts.append(prompt)
+            index = min(len(self.prompts) - 1, len(self.contents) - 1)
+        return {
+            'choices': [{
+                'message': {'content': self.contents[index]},
+                'finish_reason': 'stop',
+            }],
+            'model': CITATION_CONFIG['model'],
+            'provider': 'SiliconFlow',
+            'usage': {
+                'prompt_tokens': 100,
+                'completion_tokens': self.completion_tokens,
+                'cost': 0.0004,
+            },
+        }
+
+
+def _usage_of_request(model_impl: LlmModelImpl, token_lists, features):
+    def request():
+        accumulator = start_request_llm_usage()
+        try:
+            model_impl.predict_labels(token_lists, features)
+        except LlmResponseError:
+            pass
+        return accumulator.to_dict()
+    return contextvars.copy_context().run(request)
+
+
+class TestUsageAccumulation:
+    def test_should_attribute_every_batch_of_one_document_to_one_accumulator(self):
+        """The batches run in a thread pool, whose workers start with an empty
+        context, so this is the case a single-batch document does not cover."""
+        token_lists = [[f'Reference{index}'] for index in range(8)]
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config({
+                **CITATION_CONFIG,
+                'max_references_per_request': 1,
+                'max_concurrent_requests': 4,
+            }),
+            client=UsageClient(content=batched([]), concurrent_calls=4)
+        )
+        usage = _usage_of_request(model_impl, token_lists, no_features(token_lists))
+        assert usage is not None
+        assert usage['calls'] == 8
+        assert usage['output_tokens'] == 8 * 50
+        assert usage['by_task'][CITATION_CONFIG['task']]['calls'] == 8
+
+    def test_should_attribute_a_single_batch_document(self):
+        token_lists = [['Alpha']]
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config({
+                **CITATION_CONFIG,
+                'max_references_per_request': 1,
+                'max_concurrent_requests': 4,
+            }),
+            client=UsageClient(content=batched([]))
+        )
+        usage = _usage_of_request(model_impl, token_lists, no_features(token_lists))
+        assert usage is not None
+        assert usage['calls'] == 1
+
+    def test_should_record_usage_of_a_response_that_cannot_be_parsed(self):
+        token_lists = [['Alpha']]
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config({
+                **CITATION_CONFIG,
+                'max_references_per_request': 1,
+                'max_malformed_response_retries': 0,
+            }),
+            client=UsageClient(content='{"references": [')
+        )
+        usage = _usage_of_request(model_impl, token_lists, no_features(token_lists))
+        assert usage is not None
+        assert usage['calls'] == 1
+        assert usage['output_tokens'] == 50
+
+    def test_should_record_usage_of_every_attempt_when_asking_again(self):
+        model_impl = LlmModelImpl(
+            LlmEngineConfig.from_model_config(CONFIG),
+            client=UsageClient(content=['{"starts": [0', json.dumps({'starts': [0]})])
+        )
+        usage = _usage_of_request(model_impl, [TOKENS], [feature_rows()])
+        assert usage is not None
+        assert usage['calls'] == 2
+        assert usage['output_tokens'] == 100
+
+    def test_should_record_nothing_when_the_engine_was_not_used(self):
+        def request():
+            accumulator = start_request_llm_usage()
+            return accumulator.to_dict()
+        assert contextvars.copy_context().run(request) is None

--- a/tests/models/llm/telemetry_test.py
+++ b/tests/models/llm/telemetry_test.py
@@ -108,7 +108,7 @@ class TestSetResponseAttributes:
         attributes = span.as_dict()
         assert attributes[GEN_AI_USAGE_OUTPUT_TOKENS] == 20
         assert attributes[OPENINFERENCE_TOKEN_COUNT_COMPLETION] == 20
-        assert attributes['sciencebeam.cost_usd'] == 0.0001
+        assert attributes['sciencebeam.cost_credits'] == 0.0001
 
     def test_should_record_the_resolved_provider(self):
         span = RecordingSpan()

--- a/tests/models/llm/usage_test.py
+++ b/tests/models/llm/usage_test.py
@@ -1,0 +1,230 @@
+import contextvars
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from sciencebeam_parser.models.llm.usage import (
+    LlmUsageAccumulator,
+    get_request_llm_usage_header_value,
+    record_llm_usage,
+    start_request_llm_usage
+)
+
+
+TASK_1 = 'citation'
+TASK_2 = 'reference_segmenter'
+
+
+def _response(
+    prompt_tokens: int = 100,
+    completion_tokens: int = 50,
+    reasoning_tokens: int = 0,
+    cost=0.0004,
+    model: str = 'qwen/qwen3.5-9b',
+    provider: str = 'SiliconFlow'
+) -> dict:
+    usage: dict = {
+        'prompt_tokens': prompt_tokens,
+        'completion_tokens': completion_tokens,
+        'completion_tokens_details': {'reasoning_tokens': reasoning_tokens},
+    }
+    if cost is not None:
+        usage['cost'] = cost
+    return {'usage': usage, 'model': model, 'provider': provider}
+
+
+class TestLlmUsageAccumulator:
+    def test_should_report_nothing_without_a_call(self):
+        assert LlmUsageAccumulator().to_dict() is None
+
+    def test_should_sum_tokens_and_cost_across_calls(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, _response())
+        accumulator.add_response(TASK_1, _response())
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['calls'] == 2
+        assert usage['input_tokens'] == 200
+        assert usage['output_tokens'] == 100
+        assert usage['cost_credits'] == 0.0008
+
+    def test_should_keep_the_peak_of_a_single_call_rather_than_the_sum(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, _response(completion_tokens=50))
+        accumulator.add_response(TASK_1, _response(completion_tokens=16000))
+        accumulator.add_response(TASK_1, _response(completion_tokens=50))
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['output_tokens'] == 16100
+        assert usage['peak_output_tokens'] == 16000
+
+    def test_should_treat_reasoning_tokens_as_part_of_the_output_tokens(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(
+            TASK_1, _response(completion_tokens=500, reasoning_tokens=400)
+        )
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['output_tokens'] == 500
+        assert usage['reasoning_tokens'] == 400
+
+    def test_should_leave_cost_absent_rather_than_zero_when_unreported(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, _response(cost=None))
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert 'cost_credits' not in usage
+        assert usage['output_tokens'] == 50
+
+    def test_should_count_a_response_without_usage_as_a_call(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, {'model': 'qwen/qwen3.5-9b'})
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['calls'] == 1
+        assert usage['input_tokens'] == 0
+        assert 'cost_credits' not in usage
+
+    def test_should_break_usage_down_by_task(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, _response(completion_tokens=50))
+        accumulator.add_response(TASK_2, _response(completion_tokens=900, model='other'))
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['output_tokens'] == 950
+        assert usage['by_task'][TASK_1]['output_tokens'] == 50
+        assert usage['by_task'][TASK_2]['output_tokens'] == 900
+        assert usage['by_task'][TASK_2]['models'] == ['other']
+
+    def test_should_record_the_resolved_provider(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, _response(provider='Venice'))
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['providers'] == ['Venice']
+
+    def test_should_be_safe_to_add_to_from_several_threads(self):
+        accumulator = LlmUsageAccumulator()
+        barrier = threading.Barrier(4, timeout=5)
+
+        def add(_):
+            barrier.wait()
+            accumulator.add_response(TASK_1, _response())
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(add, range(4)))
+
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['calls'] == 4
+        assert usage['input_tokens'] == 400
+
+
+class TestRequestLlmUsage:
+    def test_should_record_nothing_without_an_accumulator(self):
+        def call_without_binding():
+            record_llm_usage(TASK_1, _response())
+            return get_request_llm_usage_header_value()
+
+        assert contextvars.copy_context().run(call_without_binding) is None
+
+    def test_should_have_no_header_value_when_no_call_was_made(self):
+        def bind_only():
+            start_request_llm_usage()
+            return get_request_llm_usage_header_value()
+
+        assert contextvars.copy_context().run(bind_only) is None
+
+    def test_should_report_what_the_request_spent_as_json(self):
+        def spend():
+            start_request_llm_usage()
+            record_llm_usage(TASK_1, _response())
+            return get_request_llm_usage_header_value()
+
+        header_value = contextvars.copy_context().run(spend)
+        assert header_value
+        assert json.loads(header_value)['input_tokens'] == 100
+
+    def test_should_keep_concurrent_requests_apart(self):
+        barrier = threading.Barrier(2, timeout=5)
+
+        def request(call_count: int) -> str:
+            start_request_llm_usage()
+            barrier.wait()
+            for _ in range(call_count):
+                record_llm_usage(TASK_1, _response())
+            header_value = get_request_llm_usage_header_value()
+            assert header_value
+            return header_value
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(
+                lambda count: contextvars.copy_context().run(request, count),
+                [3, 1]
+            ))
+
+        assert [json.loads(result)['calls'] for result in results] == [3, 1]
+
+    def test_should_reach_the_creator_when_mutated_from_a_copied_context(self):
+        def request() -> int:
+            accumulator = start_request_llm_usage()
+            contextvars.copy_context().run(record_llm_usage, TASK_1, _response())
+            return accumulator.calls
+
+        assert contextvars.copy_context().run(request) == 1
+
+
+class TestProviderReportedShape:
+    """Anchored on real OpenRouter responses: `prompt_tokens + completion_tokens`
+    is the reported `total_tokens`, so reasoning and cached tokens are breakdowns
+    of those two rather than additions to them."""
+    GPT_OSS_RESPONSE = {
+        'model': 'openai/gpt-oss-120b',
+        'provider': 'AkashML',
+        'usage': {
+            'prompt_tokens': 81,
+            'prompt_tokens_details': {'cached_tokens': 64, 'cache_write_tokens': 0},
+            'completion_tokens': 42,
+            'completion_tokens_details': {'reasoning_tokens': 20},
+            'total_tokens': 123,
+            'cost': 9.57e-06,
+            'cost_details': {'upstream_inference_cost': 9.57e-06},
+        },
+    }
+
+    def test_should_not_add_reasoning_tokens_to_the_output_tokens(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, self.GPT_OSS_RESPONSE)
+        usage = accumulator.to_dict()
+        assert usage is not None
+        reported = self.GPT_OSS_RESPONSE['usage']
+        assert usage['input_tokens'] + usage['output_tokens'] == reported['total_tokens']
+        assert usage['reasoning_tokens'] == 20
+
+    def test_should_record_provider_cached_input_tokens_as_part_of_the_input(self):
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, self.GPT_OSS_RESPONSE)
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['input_tokens'] == 81
+        assert usage['cached_input_tokens'] == 64
+
+    def test_should_record_what_a_truncated_response_spent(self):
+        truncated = {
+            'model': 'openai/gpt-oss-120b',
+            'provider': 'AkashML',
+            'choices': [{'message': {'content': ''}, 'finish_reason': 'length'}],
+            'usage': {
+                'prompt_tokens': 81,
+                'completion_tokens': 16,
+                'completion_tokens_details': {'reasoning_tokens': 10},
+                'total_tokens': 97,
+                'cost': 5.15e-06,
+            },
+        }
+        accumulator = LlmUsageAccumulator()
+        accumulator.add_response(TASK_1, truncated)
+        usage = accumulator.to_dict()
+        assert usage is not None
+        assert usage['output_tokens'] == 16
+        assert usage['cost_credits'] == 5.15e-06

--- a/tests/service/api/app_test.py
+++ b/tests/service/api/app_test.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
+import json
 import logging
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,6 +16,8 @@ from sciencebeam_parser.app.parser import (
     UnsupportedResponseMediaTypeScienceBeamParserError
 )
 from sciencebeam_parser.config.config import AppConfig
+from sciencebeam_parser.models.llm.decode import LlmResponseError
+from sciencebeam_parser.models.llm.usage import USAGE_HEADER_NAME, record_llm_usage
 from sciencebeam_parser.resources.default_config import DEFAULT_CONFIG_FILE
 from sciencebeam_parser.service.api.app import create_api_app
 from sciencebeam_parser.utils.media_types import MediaTypes
@@ -24,6 +29,12 @@ PDF_FILENAME_1 = 'test.pdf'
 PDF_CONTENT_1 = b'test pdf content'
 DOCX_CONTENT_1 = b'test docx content 1'
 XML_CONTENT_1 = b'<article></article>'
+
+LLM_RESPONSE_1 = {
+    'usage': {'prompt_tokens': 100, 'completion_tokens': 50, 'cost': 0.0001},
+    'model': 'qwen/qwen3.5-9b',
+    'provider': 'SiliconFlow',
+}
 
 TEI_XML_CONTENT_1 = b'<TEI>1</TEI>'
 JATS_XML_CONTENT_1 = b'<article>1</article>'
@@ -464,3 +475,111 @@ class TestApiApp:
             )
             assert response.status_code == 200
             assert response.content == PDF_CONTENT_1
+
+
+class TestLlmUsageHeader:
+    """The response carries what the request spent, on both paths.
+
+    `get_local_file_for_response_media_type` stands in for the work of the
+    request: what matters here is that a completion recorded inside the handler
+    reaches the response, and that a handler which raises still reports it.
+    """
+    def _usage_recording_side_effect(self, output_path: Path, calls: int):
+        def side_effect(*_args, **_kwargs):
+            for _ in range(calls):
+                record_llm_usage('citation', LLM_RESPONSE_1)
+            return str(output_path)
+        return side_effect
+
+    def test_should_report_what_the_request_spent(
+        self,
+        test_client: TestClient,
+        get_local_file_for_response_media_type_mock: MagicMock,
+        request_temp_path: Path
+    ):
+        output_path = request_temp_path / 'result.xml'
+        output_path.write_bytes(TEI_XML_CONTENT_1)
+        get_local_file_for_response_media_type_mock.side_effect = (
+            self._usage_recording_side_effect(output_path, calls=3)
+        )
+        response = test_client.post('/processFulltextDocument', files={
+            'input': (PDF_FILENAME_1, BytesIO(PDF_CONTENT_1))
+        })
+        assert response.status_code == 200
+        assert response.content == TEI_XML_CONTENT_1
+        usage = json.loads(response.headers[USAGE_HEADER_NAME])
+        assert usage['calls'] == 3
+        assert usage['input_tokens'] == 300
+        assert usage['cost_credits'] == pytest.approx(0.0003)
+        assert usage['by_task']['citation']['calls'] == 3
+
+    def test_should_report_what_a_failed_request_had_already_spent(
+        self,
+        sciencebeam_parser_mock: MagicMock,
+        get_local_file_for_response_media_type_mock: MagicMock
+    ):
+        def side_effect(*_args, **_kwargs):
+            record_llm_usage('citation', LLM_RESPONSE_1)
+            raise LlmResponseError('response could not be parsed')
+        get_local_file_for_response_media_type_mock.side_effect = side_effect
+        client = TestClient(
+            create_api_app(sciencebeam_parser=sciencebeam_parser_mock),
+            raise_server_exceptions=False
+        )
+        response = client.post('/processFulltextDocument', files={
+            'input': (PDF_FILENAME_1, BytesIO(PDF_CONTENT_1))
+        })
+        assert response.status_code == 500
+        usage = json.loads(response.headers[USAGE_HEADER_NAME])
+        assert usage['calls'] == 1
+        assert usage['input_tokens'] == 100
+
+    def test_should_not_add_a_header_when_no_llm_engine_ran(
+        self,
+        test_client: TestClient,
+        get_local_file_for_response_media_type_mock: MagicMock,
+        request_temp_path: Path
+    ):
+        output_path = request_temp_path / 'result.xml'
+        output_path.write_bytes(TEI_XML_CONTENT_1)
+        get_local_file_for_response_media_type_mock.return_value = str(output_path)
+        response = test_client.post('/processFulltextDocument', files={
+            'input': (PDF_FILENAME_1, BytesIO(PDF_CONTENT_1))
+        })
+        assert response.status_code == 200
+        assert USAGE_HEADER_NAME not in response.headers
+
+    def test_should_keep_concurrent_requests_apart(
+        self,
+        test_client: TestClient,
+        get_local_file_for_response_media_type_mock: MagicMock,
+        request_temp_path: Path
+    ):
+        output_path = request_temp_path / 'result.xml'
+        output_path.write_bytes(TEI_XML_CONTENT_1)
+        barrier = threading.Barrier(2, timeout=5)
+        calls_per_request = iter([3, 1])
+        lock = threading.Lock()
+
+        def side_effect(*_args, **_kwargs):
+            with lock:
+                calls = next(calls_per_request)
+            # Both requests are inside the handler before either records, so a
+            # shared accumulator would report 4 to both of them.
+            barrier.wait()
+            for _ in range(calls):
+                record_llm_usage('citation', LLM_RESPONSE_1)
+            return str(output_path)
+        get_local_file_for_response_media_type_mock.side_effect = side_effect
+
+        def post(_index: int) -> int:
+            response = test_client.post('/processFulltextDocument', files={
+                'input': (PDF_FILENAME_1, BytesIO(PDF_CONTENT_1))
+            })
+            assert response.status_code == 200
+            return json.loads(response.headers[USAGE_HEADER_NAME])['calls']
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            reported = list(pool.map(post, range(2)))
+
+        assert sorted(reported) == [1, 3]


### PR DESCRIPTION
The engine merged in #702 already obtains what every call spent — the completion body carries `usage` and the resolved provider, and both call sites hand it to the tracing layer. From there it goes onto an OpenTelemetry span and no further. Reading a span needs a collector, and a benchmark job starts neither Phoenix nor storage for spans, so an LLM variant's **quality** has been published per corpus on every run while its **price** has been visible only to whoever happened to be running one locally.

This puts the two side by side, in the file that already reaches the job summary and the PR comment.

## What it makes possible

**Weighing a quality number against what it cost.** The comparison #702 set up is an LLM variant against a CRF baseline that costs nothing, and until now the report gave no way to say what the difference bought. Per variant and per corpus, `comparison.md` now carries calls, input and output tokens, the peak single call, and credits — beside the F1 deltas they belong to, with a per-document mean so variants of unequal length stay comparable.

**The alarm that fires before documents start failing.** The completion ceiling is the binding constraint for segmentation, the client already raises when a response hits it, and a reasoning-mandatory model spends that budget before it answers. A rising output-token count is the warning that arrives first — and the number that carries it is the **largest single call**, not the document total, which rises with reference-list length and says nothing about proximity to the limit. Both are reported; the peak is the one to watch.

**Knowing which model is spending it.** Usage is attributed per task as well as in total, so a profile running the reference segmenter and the citation parser can say which of them the cost came from. That only gets more useful as more tasks go behind the engine.

**A variant whose failures look free can't be chosen for the wrong reason.** Recording happens where the response body arrives, before anything decides it is usable, so a document that errored still reports what it paid — including a response that ran out of room, which is billed in full and produces nothing. The aggregate deliberately covers every document attempted rather than the scored subset, and says so, because a variant that failed on thirty documents still spent their tokens.

**No new infrastructure to run, scrape or remember to start.** No collector, no dashboard, no second report. Usage rides back on the response, into the manifest the benchmark already writes per document, into `summary.json`, into `comparison.md` — the path that already publishes the scores.

**Nothing changes unless an LLM ran.** A CRF-only run's API responses, manifest entries, summary and report are byte-for-byte what they were. No header, no empty fields, no new log line.

## What the numbers say that the numbers alone don't

Two provider behaviours would otherwise make the report quietly misleading, and both are handled rather than assumed:

- **Reasoning tokens are part of the output tokens, not extra.** The provider reports `prompt_tokens + completion_tokens` as its `total_tokens`, with reasoning counted inside the completion — verified against a reasoning-mandatory model, where the additive reading would have put the total 20 tokens higher than reported. The report shows the breakdown and never sums it.
- **Provider-side prompt caching moves cost without moving tokens.** The same input reported 0 and then 528 cached tokens across two runs. Without recording it, a variant can look cheaper for a reason no other number in the table explains; the report notes it where it happened.

The report also states how many documents of each variant have usage recorded. A baseline served from the predictions store contributes numbers an earlier run paid for, and a manifest written before this change carries none — both are honest states, and the count is what tells them apart from a variant that genuinely spent nothing.
